### PR TITLE
Write the suffix as an integer.

### DIFF
--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/FileProcessor.scala
@@ -126,7 +126,7 @@ class FileProcessor(
         fileInfo.fileName,
         fileInfo.fileSize,
         Preservation,
-        "1"
+        1
       )
     val fileMetadataObject = BagitFileMetadataObject(
       metadataFileInfo.id,
@@ -136,7 +136,7 @@ class FileProcessor(
       metadataFileInfo.fileName,
       metadataFileInfo.fileSize,
       Preservation,
-      "1"
+      1
     )
     List(folderMetadataObject, assetMetadataObject, fileRowMetadataObject, fileMetadataObject)
   }
@@ -334,7 +334,7 @@ object FileProcessor {
           ("sortOrder", Json.fromInt(sortOrder)),
           ("fileSize", Json.fromLong(fileSize)),
           ("representationType", Json.fromString(representationType.toString)),
-          ("representationSuffix", Json.fromString(representationSuffix))
+          ("representationSuffix", Json.fromInt(representationSuffix))
         )
         .deepMerge(jsonFromMetadataObject(id, parentId, Option(title), File, name))
   }
@@ -422,7 +422,7 @@ object FileProcessor {
       name: String,
       fileSize: Long,
       representationType: RepresentationType,
-      representationSuffix: String
+      representationSuffix: Int
   ) extends BagitMetadataObject
 
   case class BagInfo(

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/FileProcessorTest.scala
@@ -365,8 +365,8 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
                   ).flatten
                 )
               val files = List(
-                BagitFileMetadataObject(fileId, Option(assetId), fileName, 1, treFileName, 1, Preservation, "1"),
-                BagitFileMetadataObject(metadataId, Option(assetId), "", 2, "metadataFileName.txt", 2, Preservation, "1")
+                BagitFileMetadataObject(fileId, Option(assetId), fileName, 1, treFileName, 1, Preservation, 1),
+                BagitFileMetadataObject(metadataId, Option(assetId), "", 2, "metadataFileName.txt", 2, Preservation, 1)
               )
               val expectedBagitMetadataObjects: List[BagitMetadataObject] = List(folder, asset) ++ files
 
@@ -431,8 +431,8 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
                 ).flatten
               )
             val files = List(
-              BagitFileMetadataObject(fileId, Option(assetId), fileName, 1, treFileName, 1, Preservation, "1"),
-              BagitFileMetadataObject(metadataId, Option(assetId), "", 2, "metadataFileName.txt", 2, Preservation, "1")
+              BagitFileMetadataObject(fileId, Option(assetId), fileName, 1, treFileName, 1, Preservation, 1),
+              BagitFileMetadataObject(metadataId, Option(assetId), "", 2, "metadataFileName.txt", 2, Preservation, 1)
             )
             val metadataJsonList: List[BagitMetadataObject] = List(folder, asset) ++ files
             val metadataJsonString = metadataJsonList.asJson.printWith(Printer.noSpaces)
@@ -523,7 +523,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
               "metadataFileName.txt",
               2,
               Preservation,
-              "1"
+              1
             )
           ),
           fileInfo,

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -257,7 +257,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
           """"transferringBody":"test-organisation","transferCompleteDatetime":"2023-10-31T13:40:54Z",""" +
           """"upstreamSystem":"TRE: FCL Parser workflow","digitalAssetSource":"Born Digital","digitalAssetSubtype":"FCL"}"""
       val expectedFileMetadata = List(
-        BagitFileMetadataObject(fileId, Option(assetId), "Test", 1, "Test.docx", 15684, Preservation, "1"),
+        BagitFileMetadataObject(fileId, Option(assetId), "Test", 1, "Test.docx", 15684, Preservation, 1),
         BagitFileMetadataObject(
           metadataFileId,
           Option(assetId),
@@ -266,7 +266,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
           "TRE-TEST-REFERENCE-metadata.json",
           215,
           Preservation,
-          "1"
+          1
         )
       )
 


### PR DESCRIPTION
We're expecting this to be an integer in Dynamo but it's a string in the
Bagit json. This should write it to the bagit file as a number so it
should end up in Dynamo as a number.
