### PR TITLE
Move assetName out of SNS message and into main output & reaplace with assetId

### DIFF
--- a/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -391,11 +391,12 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
 
     stateOutput.wasReconciled should equal(true)
     stateOutput.reason should equal("")
+    stateOutput.assetName should equal(assetName)
 
     val message = stateOutput.reconciliationSnsMessage.get
 
     message.reconciliationUpdate should equal("Asset was reconciled")
-    message.assetName should equal(assetName)
+    message.assetId should equal(assetId)
     message.properties.messageId should equal(newMessageId)
     message.properties.parentMessageId should equal(UUID.fromString("787bf94b-efdc-4d4b-a93c-a0e537d089fd"))
     message.properties.executionId should equal("TEST-ID")
@@ -421,11 +422,12 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
 
       stateOutput.wasReconciled should equal(true)
       stateOutput.reason should equal("")
+      stateOutput.assetName should equal(assetName)
 
       val message = stateOutput.reconciliationSnsMessage.get
 
       message.reconciliationUpdate should equal("Asset was reconciled")
-      message.assetName should equal(assetName)
+      message.assetId should equal(assetId)
       message.properties.messageId should equal(newMessageId)
       message.properties.parentMessageId should equal(UUID.fromString("787bf94b-efdc-4d4b-a93c-a0e537d089fd"))
       message.properties.executionId should equal("TEST-ID")
@@ -455,11 +457,12 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
 
       stateOutput.wasReconciled should equal(true)
       stateOutput.reason should equal("")
+      stateOutput.assetName should equal(assetName)
 
       val message = stateOutput.reconciliationSnsMessage.get
 
       message.reconciliationUpdate should equal("Asset was reconciled")
-      message.assetName should equal(assetName)
+      message.assetId should equal(assetId)
       message.properties.messageId should equal(newMessageId)
       message.properties.parentMessageId should equal(UUID.fromString("787bf94b-efdc-4d4b-a93c-a0e537d089fd"))
       message.properties.executionId should equal("TEST-ID")


### PR DESCRIPTION
'assetName' is not needed for SNS message but it is needed for the next step in step function, therefore, it makes more sense to put it in the main output.

In the SNS message, assetId was replaced with assetName but we actually need it for the message