### PR TITLE
Dr2 1672 add updated partition keys and account for missing execution

### DIFF
--- a/ingest-asset-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-asset-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -26,7 +26,7 @@ class Lambda extends LambdaRunner[Input, Unit, Config, Dependencies] {
     val dynamoClient = dependencies.dynamoClient
     val s3Client = dependencies.s3Client
     for {
-      assetItems <- dynamoClient.getItems[AssetDynamoTable, PartitionKey](List(PartitionKey(input.id)), config.dynamoTableName)
+      assetItems <- dynamoClient.getItems[AssetDynamoTable, FilesTablePartitionKey](List(FilesTablePartitionKey(input.id)), config.dynamoTableName)
       asset <- IO.fromOption(assetItems.headOption)(
         new Exception(s"No asset found for ${input.id} and ${input.batchId}")
       )

--- a/ingest-asset-reconciler/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-asset-reconciler/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -90,8 +90,8 @@ class Lambda extends LambdaRunner[Input, StateOutput, Config, Dependencies] {
 
   private def generateSnsMessage(dependencies: Dependencies, assetName: UUID, lockTableName: String, batchId: String, assetId: UUID) =
     for {
-      items <- dependencies.dynamoDbClient.getItems[IngestLockTable, PartitionKey](
-        List(PartitionKey(assetName)),
+      items <- dependencies.dynamoDbClient.getItems[IngestLockTable, LockTablePartitionKey](
+        List(LockTablePartitionKey(assetName)),
         lockTableName
       )
 
@@ -118,8 +118,8 @@ class Lambda extends LambdaRunner[Input, StateOutput, Config, Dependencies] {
   ) => IO[StateOutput] = (input, config, dependencies) =>
     for {
       assetId <- IO.pure(input.assetId)
-      assetItems <- dependencies.dynamoDbClient.getItems[AssetDynamoTable, PartitionKey](
-        List(PartitionKey(assetId)),
+      assetItems <- dependencies.dynamoDbClient.getItems[AssetDynamoTable, FilesTablePartitionKey](
+        List(FilesTablePartitionKey(assetId)),
         config.dynamoTableName
       )
 

--- a/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
+++ b/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/LambdaTest.scala
@@ -204,7 +204,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     }
     ex.getMessage should equal(s"No asset found for $assetId from $batchId")
 
-    argumentVerifier.verifyInvocationsAndArgumentsPassed(0, 0, 0, 0)
+    argumentVerifier.verifyInvocationsAndArgumentsPassed(0, 0, 0, 0, 1, 0)
   }
 
   "handler" should "return an error if the Dynamo entry does not have a type of 'Asset'" in {
@@ -216,7 +216,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     }
     ex.getMessage should equal(s"Object $assetId is of type ArchiveFolder and not 'Asset'")
 
-    argumentVerifier.verifyInvocationsAndArgumentsPassed(0, 0, 0, 0)
+    argumentVerifier.verifyInvocationsAndArgumentsPassed(0, 0, 0, 0, 1, 0)
   }
 
   "handler" should "return an error if there were no entities that had the asset name as the SourceId" in {
@@ -228,7 +228,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     }
     ex.getMessage should equal(s"No entity found using SourceId 'acdb2e57-923b-4caa-8fd9-a2f79f650c43'")
 
-    argumentVerifier.verifyInvocationsAndArgumentsPassed(1, 0, 0, 0)
+    argumentVerifier.verifyInvocationsAndArgumentsPassed(1, 0, 0, 0, 1, 0)
   }
 
   "handler" should "return an error if no children are found for the asset" in {
@@ -346,7 +346,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
       "No items found for ioId 'acdb2e57-923b-4caa-8fd9-a2f79f650c43' from batchId 'TEST-ID'"
     )
 
-    argumentVerifier.verifyInvocationsAndArgumentsPassed()
+    argumentVerifier.verifyInvocationsAndArgumentsPassed(numOfFileTableGetRequests = 1, numOfFileTableUpdateRequests = 1, numOfLockTableGetRequests = 1)
   }
 
   "handler" should "return an error if COs could be reconciled but the 'executionId' from the lock table does not match " +
@@ -363,7 +363,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
         "executionId 'b13ea544-7452-4f53-9db9-c7510c684855' belonging to ioId 'acdb2e57-923b-4caa-8fd9-a2f79f650c43' does not equal 'TEST-ID'"
       )
 
-      argumentVerifier.verifyInvocationsAndArgumentsPassed()
+      argumentVerifier.verifyInvocationsAndArgumentsPassed(numOfFileTableGetRequests = 1, numOfFileTableUpdateRequests = 1, numOfLockTableGetRequests = 1)
     }
 
   "handler" should "return a 'decoding' error if COs could be reconciled but the 'messageId' was missing from lock table" in {
@@ -377,7 +377,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     }
     ex.getMessage should equal(s"DecodingFailure at .messageId: Missing required field")
 
-    argumentVerifier.verifyInvocationsAndArgumentsPassed()
+    argumentVerifier.verifyInvocationsAndArgumentsPassed(numOfFileTableGetRequests = 1, numOfFileTableUpdateRequests = 1, numOfLockTableGetRequests = 1)
   }
 
   "handler" should "return a 'wasReconciled' value of 'true' and an empty 'reason' if COs could be reconciled" in {
@@ -401,7 +401,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     message.properties.parentMessageId should equal(UUID.fromString("787bf94b-efdc-4d4b-a93c-a0e537d089fd"))
     message.properties.executionId should equal("TEST-ID")
 
-    argumentVerifier.verifyInvocationsAndArgumentsPassed()
+    argumentVerifier.verifyInvocationsAndArgumentsPassed(numOfFileTableGetRequests = 1, numOfFileTableUpdateRequests = 1, numOfLockTableGetRequests = 1)
   }
 
   forAll(uncommonButAcceptableFileExtensionStates) { (childOfAssetDocxTitle, entityTitle, stateOfTitleExtension) =>
@@ -432,7 +432,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
       message.properties.parentMessageId should equal(UUID.fromString("787bf94b-efdc-4d4b-a93c-a0e537d089fd"))
       message.properties.executionId should equal("TEST-ID")
 
-      argumentVerifier.verifyInvocationsAndArgumentsPassed()
+      argumentVerifier.verifyInvocationsAndArgumentsPassed(numOfFileTableGetRequests = 1, numOfFileTableUpdateRequests = 1, numOfLockTableGetRequests = 1)
     }
   }
 
@@ -467,6 +467,6 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
       message.properties.parentMessageId should equal(UUID.fromString("787bf94b-efdc-4d4b-a93c-a0e537d089fd"))
       message.properties.executionId should equal("TEST-ID")
 
-      argumentVerifier.verifyInvocationsAndArgumentsPassed()
+      argumentVerifier.verifyInvocationsAndArgumentsPassed(numOfFileTableGetRequests = 1, numOfFileTableUpdateRequests = 1, numOfLockTableGetRequests = 1)
     }
 }

--- a/ingest-check-preservica-for-existing-io/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-check-preservica-for-existing-io/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -25,8 +25,8 @@ class Lambda extends LambdaRunner[Input, StateOutput, Config, Dependencies] {
       Dependencies
   ) => IO[StateOutput] = (input, config, dependencies) =>
     for {
-      assetItems <- dependencies.dynamoDbClient.getItems[AssetDynamoTable, PartitionKey](
-        List(PartitionKey(input.id)),
+      assetItems <- dependencies.dynamoDbClient.getItems[AssetDynamoTable, FilesTablePartitionKey](
+        List(FilesTablePartitionKey(input.id)),
         config.dynamoTableName
       )
       asset <- IO.fromOption(assetItems.headOption)(

--- a/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -74,7 +74,7 @@ class Lambda extends LambdaRunner[Input, Unit, Config, Dependencies] {
       Dependencies
   ) => IO[Unit] = (input, config, dependencies) =>
     for {
-      folderItems <- dependencies.dynamoClient.getItems[ArchiveFolderDynamoTable, PartitionKey](List(PartitionKey(input.id)), config.dynamoTableName)
+      folderItems <- dependencies.dynamoClient.getItems[ArchiveFolderDynamoTable, FilesTablePartitionKey](List(FilesTablePartitionKey(input.id)), config.dynamoTableName)
       folder <- IO.fromOption(folderItems.headOption)(
         new Exception(s"No folder found for ${input.id} and ${input.batchId}")
       )

--- a/ingest-upsert-archive-folders/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-upsert-archive-folders/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -28,8 +28,8 @@ class Lambda extends LambdaRunner[StepFnInput, Unit, Config, Dependencies] {
   ) => IO[Unit] = (stepFnInput, config, dependencies) => {
     val logWithBatchRef = log(Map("batchRef" -> stepFnInput.batchId))(_)
 
-    val folderIdPartitionKeysAndValues: List[PartitionKey] =
-      stepFnInput.archiveHierarchyFolders.map(UUID.fromString).map(PartitionKey.apply)
+    val folderIdPartitionKeysAndValues: List[FilesTablePartitionKey] =
+      stepFnInput.archiveHierarchyFolders.map(UUID.fromString).map(FilesTablePartitionKey.apply)
 
     for {
       folderRowsSortedByParentPath <- getFolderRowsSortedByParentPath(
@@ -167,11 +167,11 @@ class Lambda extends LambdaRunner[StepFnInput, Unit, Config, Dependencies] {
 
   private def getFolderRowsSortedByParentPath(
       dADynamoDBClient: DADynamoDBClient[IO],
-      folderIdPartitionKeysAndValues: List[PartitionKey],
+      folderIdPartitionKeysAndValues: List[FilesTablePartitionKey],
       archiveFolderTableName: String
   ): IO[List[DynamoTable]] = {
     val getItemsResponse: IO[List[DynamoTable]] =
-      dADynamoDBClient.getItems[ArchiveFolderDynamoTable, PartitionKey](
+      dADynamoDBClient.getItems[ArchiveFolderDynamoTable, FilesTablePartitionKey](
         folderIdPartitionKeysAndValues,
         archiveFolderTableName
       )

--- a/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/testUtils/ExternalServicesTestUtils.scala
+++ b/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/testUtils/ExternalServicesTestUtils.scala
@@ -265,17 +265,17 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
 
     val entityCaptor: ArgumentCaptor[Entity] = ArgumentCaptor.forClass(classOf[Entity])
 
-    def getPartitionKeysCaptor: ArgumentCaptor[List[PartitionKey]] =
-      ArgumentCaptor.forClass(classOf[List[PartitionKey]])
+    def getPartitionKeysCaptor: ArgumentCaptor[List[FilesTablePartitionKey]] =
+      ArgumentCaptor.forClass(classOf[List[FilesTablePartitionKey]])
     def getTableNameCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
 
     val mockEntityClient: EntityClient[IO, Fs2Streams[IO]] = mock[EntityClient[IO, Fs2Streams[IO]]]
     val mockDynamoDBClient: DADynamoDBClient[IO] = mock[DADynamoDBClient[IO]]
 
     when(
-      mockDynamoDBClient.getItems[ArchiveFolderDynamoTable, PartitionKey](any[List[PartitionKey]], any[String])(using
+      mockDynamoDBClient.getItems[ArchiveFolderDynamoTable, FilesTablePartitionKey](any[List[FilesTablePartitionKey]], any[String])(using
         any[DynamoFormat[ArchiveFolderDynamoTable]],
-        any[DynamoFormat[PartitionKey]]
+        any[DynamoFormat[FilesTablePartitionKey]]
       )
     ).thenReturn(
       getAttributeValuesReturnValue
@@ -318,12 +318,12 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
     ): Unit = {
       val attributesValuesCaptor = getPartitionKeysCaptor
       val tableNameCaptor = getTableNameCaptor
-      verify(mockDynamoDBClient, times(1)).getItems[ArchiveFolderDynamoTable, PartitionKey](
+      verify(mockDynamoDBClient, times(1)).getItems[ArchiveFolderDynamoTable, FilesTablePartitionKey](
         attributesValuesCaptor.capture(),
         tableNameCaptor.capture()
-      )(using any[DynamoFormat[ArchiveFolderDynamoTable]], any[DynamoFormat[PartitionKey]])
+      )(using any[DynamoFormat[ArchiveFolderDynamoTable]], any[DynamoFormat[FilesTablePartitionKey]])
       attributesValuesCaptor.getValue.toArray.toList should be(
-        folderIdsAndRows.map { case (ids, _) => PartitionKey(ids) }
+        folderIdsAndRows.map { case (ids, _) => FilesTablePartitionKey(ids) }
       )
 
       val entitiesByIdentifierIdentifierToGetCaptor = getIdentifierToGetCaptor

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -19,7 +19,7 @@ object Dependencies {
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val commonsCompress = "org.apache.commons" % "commons-compress" % "1.26.1"
   lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % daAwsClientsVersion
-  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.15"
+  lazy val dynamoFormatters = "uk.gov.nationalarchives" %% "dynamo-formatters" % "0.0.16"
   lazy val eventBridgeClient = "uk.gov.nationalarchives" %% "da-eventbridge-client" % daAwsClientsVersion
   lazy val fs2Core = "co.fs2" %% "fs2-core" % fs2Version
   lazy val fs2IO = "co.fs2" %% "fs2-io" % fs2Version


### PR DESCRIPTION
This PR:

1. Renames "PartitionKey"
2. Accounts for the fact that the executionId in "message" could be missing
3. Verifies the request sent to the lock table in the tests