### PR TITLE
Correct the by-identifier endpoint.

### DIFF
--- a/get-latest-preservica-version-lambda/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/get-latest-preservica-version-lambda/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -14,7 +14,7 @@ import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
 
 class Lambda extends LambdaRunner[ScheduledEvent, Unit, Config, Dependencies] {
 
-  private val lowImpactEndpoint = "by-identifier?type=tnaTest&value=getLatestPreservicaVersion"
+  private val lowImpactEndpoint = "entities/by-identifier?type=tnaTest&value=getLatestPreservicaVersion"
 
   override def handler: (ScheduledEvent, Config, Dependencies) => IO[Unit] = { (_, config, dependencies) =>
     for {

--- a/get-latest-preservica-version-lambda/src/test/scala/uk/gov/nationalarchives/testUtils/ExternalServicesTestUtils.scala
+++ b/get-latest-preservica-version-lambda/src/test/scala/uk/gov/nationalarchives/testUtils/ExternalServicesTestUtils.scala
@@ -89,7 +89,7 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
         endpointSinceCaptor.capture()
       )
       (0 until numOfLatestPreservicaVersionInvocations).foreach { _ =>
-        endpointSinceCaptor.getValue should be("by-identifier?type=tnaTest&value=getLatestPreservicaVersion")
+        endpointSinceCaptor.getValue should be("entities/by-identifier?type=tnaTest&value=getLatestPreservicaVersion")
       }
 
       verify(mockSnsClient, times(numOfPublishInvocations)).publish(


### PR DESCRIPTION
The endpoint is /entity/entities/by-identifier. We were only calling
/entity/by-identifier.
