### PR TITLE
DR2-1702 Remove temporary classes.

### DIFF
--- a/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends entityeventgenerator.Lambda

--- a/get-latest-preservica-version-lambda/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/get-latest-preservica-version-lambda/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends getlatestpreservicaversion.Lambda

--- a/ingest-asset-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-asset-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestassetopexcreator.Lambda

--- a/ingest-asset-reconciler/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-asset-reconciler/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestassetreconciler.Lambda

--- a/ingest-find-existing-asset/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-find-existing-asset/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestfindexistingasset.Lambda

--- a/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestfolderopexcreator.Lambda

--- a/ingest-mapper/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-mapper/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestmapper.Lambda

--- a/ingest-parent-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-parent-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestparentfolderopexcreator.Lambda

--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestparsedcourtdocumenteventhandler.Lambda

--- a/ingest-start-workflow/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-start-workflow/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingeststartworkflow.Lambda

--- a/ingest-upsert-archive-folders/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-upsert-archive-folders/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestupsertarchivefolders.Lambda

--- a/ingest-workflow-monitor/src/main/scala/uk/gov/nationalarchives/Lambda.scala
+++ b/ingest-workflow-monitor/src/main/scala/uk/gov/nationalarchives/Lambda.scala
@@ -1,3 +1,0 @@
-package uk.gov.nationalarchives
-
-class Lambda extends ingestworkflowmonitor.Lambda


### PR DESCRIPTION
These were added so we could deploy without breaking things. The
terraform changes are in so these can be deleted.
