### PR TITLE
DR2-1716 Update lambda name

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -168,7 +168,6 @@ lazy val ingestFindExistingAsset = (project in file("ingest-find-existing-asset"
   .settings(commonSettings)
   .dependsOn(utils)
   .settings(
-    name := "ingest-check-preservica-for-existing-io", //This stops the name change breaking the existing lambda. This can be removed when we rename the lambda
     libraryDependencies ++= Seq(
       dynamoClient,
       dynamoFormatters,


### PR DESCRIPTION
This is a case of removing the override that gave it the old name. This
can't be deployed until
https://github.com/nationalarchives/dr2-terraform-environments/pull/124
is merged and deployed.
