### PR TITLE
DR2-1709 Add child count to case classes

### DIFF
--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormatters.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormatters.scala
@@ -80,6 +80,7 @@ object DynamoFormatters {
   val representationType = "representationType"
   val representationSuffix = "representationSuffix"
   val ingestedPreservica = "ingested_PS"
+  val childCount = "childCount"
 
   given filesTablePkFormat: Typeclass[FilesTablePartitionKey] = deriveDynamoFormat[FilesTablePartitionKey]
   given lockTablePkFormat: Typeclass[LockTablePartitionKey] = deriveDynamoFormat[LockTablePartitionKey]
@@ -96,6 +97,7 @@ object DynamoFormatters {
     def title: Option[String]
     def description: Option[String]
     def identifiers: List[Identifier]
+    def childCount: Int
   }
 
   private type ValidatedField[T] = ValidatedNel[(FieldName, DynamoReadError), T]
@@ -128,7 +130,8 @@ object DynamoFormatters {
       representationType: ValidatedField[FileRepresentationType],
       representationSuffix: ValidatedField[Int],
       ingestedPreservica: Option[String],
-      identifiers: List[Identifier]
+      identifiers: List[Identifier],
+      childCount: ValidatedField[Int]
   )
 
   case class ArchiveFolderDynamoTable(
@@ -139,7 +142,8 @@ object DynamoFormatters {
       `type`: Type,
       title: Option[String],
       description: Option[String],
-      identifiers: List[Identifier]
+      identifiers: List[Identifier],
+      childCount: Int
   ) extends DynamoTable
 
   case class ContentFolderDynamoTable(
@@ -150,7 +154,8 @@ object DynamoFormatters {
       `type`: Type,
       title: Option[String],
       description: Option[String],
-      identifiers: List[Identifier]
+      identifiers: List[Identifier],
+      childCount: Int
   ) extends DynamoTable
 
   case class AssetDynamoTable(
@@ -169,7 +174,8 @@ object DynamoFormatters {
       originalFiles: List[UUID],
       originalMetadataFiles: List[UUID],
       ingestedPreservica: Boolean,
-      identifiers: List[Identifier]
+      identifiers: List[Identifier],
+      childCount: Int
   ) extends DynamoTable
 
   case class FileDynamoTable(
@@ -187,7 +193,8 @@ object DynamoFormatters {
       representationType: FileRepresentationType,
       representationSuffix: Int,
       ingestedPreservica: Boolean,
-      identifiers: List[Identifier]
+      identifiers: List[Identifier],
+      childCount: Int
   ) extends DynamoTable
 
   case class Identifier(identifierName: String, value: String)

--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoReadUtils.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoReadUtils.scala
@@ -63,7 +63,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
     stringToRepresentationType(getPotentialStringValue(representationType)),
     getNumber(representationSuffix, _.toInt),
     getPotentialStringValue(ingestedPreservica),
-    identifiers
+    identifiers,
+    getNumber(childCount, _.toInt)
   )
 
   private def stringToType(potentialTypeString: Option[String]): ValidatedNel[InvalidProperty, Type] =
@@ -178,8 +179,9 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
       allValidatedFileTableFields.batchId,
       allValidatedFileTableFields.id,
       allValidatedFileTableFields.name,
-      allValidatedFileTableFields.`type`
-    ).mapN { (batchId, id, name, rowType) =>
+      allValidatedFileTableFields.`type`,
+      allValidatedFileTableFields.childCount
+    ).mapN { (batchId, id, name, rowType, childCount) =>
       ArchiveFolderDynamoTable(
         batchId,
         id,
@@ -188,7 +190,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
         rowType,
         allValidatedFileTableFields.title,
         allValidatedFileTableFields.description,
-        allValidatedFileTableFields.identifiers
+        allValidatedFileTableFields.identifiers,
+        childCount
       )
     }.toEither
       .left
@@ -199,8 +202,9 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
       allValidatedFileTableFields.batchId,
       allValidatedFileTableFields.id,
       allValidatedFileTableFields.name,
-      allValidatedFileTableFields.`type`
-    ).mapN { (batchId, id, name, rowType) =>
+      allValidatedFileTableFields.`type`,
+      allValidatedFileTableFields.childCount
+    ).mapN { (batchId, id, name, rowType, childCount) =>
       ContentFolderDynamoTable(
         batchId,
         id,
@@ -209,7 +213,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
         rowType,
         allValidatedFileTableFields.title,
         allValidatedFileTableFields.description,
-        allValidatedFileTableFields.identifiers
+        allValidatedFileTableFields.identifiers,
+        childCount
       )
     }.toEither
       .left
@@ -227,7 +232,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
       allValidatedFileTableFields.digitalAssetSubtype,
       allValidatedFileTableFields.originalFiles,
       allValidatedFileTableFields.originalMetadataFiles,
-      allValidatedFileTableFields.`type`
+      allValidatedFileTableFields.`type`,
+      allValidatedFileTableFields.childCount
     ).mapN {
       (
           batchId,
@@ -240,7 +246,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
           digitalAssetSubtype,
           originalFiles,
           originalMetadataFiles,
-          rowType
+          rowType,
+          childCount
       ) =>
         AssetDynamoTable(
           batchId,
@@ -258,7 +265,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
           originalFiles,
           originalMetadataFiles,
           allValidatedFileTableFields.ingestedPreservica.contains("true"),
-          allValidatedFileTableFields.identifiers
+          allValidatedFileTableFields.identifiers,
+          childCount
         )
     }.toEither
       .left
@@ -275,7 +283,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
       allValidatedFileTableFields.fileExtension,
       allValidatedFileTableFields.`type`,
       allValidatedFileTableFields.representationType,
-      allValidatedFileTableFields.representationSuffix
+      allValidatedFileTableFields.representationSuffix,
+      allValidatedFileTableFields.childCount
     ).mapN {
       (
           batchId,
@@ -287,7 +296,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
           fileExtension,
           rowType,
           representationType,
-          representationSuffix
+          representationSuffix,
+          childCount
       ) =>
         FileDynamoTable(
           batchId,
@@ -304,7 +314,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
           representationType,
           representationSuffix,
           allValidatedFileTableFields.ingestedPreservica.contains("true"),
-          allValidatedFileTableFields.identifiers
+          allValidatedFileTableFields.identifiers,
+          childCount
         )
     }.toEither
       .left

--- a/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
+++ b/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
@@ -27,7 +27,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       typeField -> fromS("ArchiveFolder"),
       title -> fromS("title"),
       description -> fromS("description"),
-      "id_Test" -> fromS("testIdentifier")
+      "id_Test" -> fromS("testIdentifier"),
+      childCount -> fromN("1")
     )
 
   val allFileFieldsPopulated: Map[String, AttributeValue] =
@@ -46,7 +47,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       representationType -> fromS("Preservation"),
       ingestedPreservica -> fromS("true"),
       representationSuffix -> fromN("1"),
-      "id_Test" -> fromS("testIdentifier")
+      "id_Test" -> fromS("testIdentifier"),
+      childCount -> fromN("1")
     )
   val allAssetFieldsPopulated: Map[String, AttributeValue] = {
     Map(
@@ -66,7 +68,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       ingestedPreservica -> fromS("true"),
       description -> fromS("testDescription"),
       "id_Test" -> fromS("testIdentifier"),
-      "id_Test2" -> fromS("testIdentifier2")
+      "id_Test2" -> fromS("testIdentifier2"),
+      childCount -> fromN("1")
     )
   }
 
@@ -78,7 +81,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       (id, UUID.randomUUID().toString),
       (batchId, "batchId"),
       (name, "name"),
-      (typeField, typeValue)
+      (typeField, typeValue),
+      (childCount, "1")
     )
     val fields = typeValue match {
       case "ArchiveFolder" => baseFields
@@ -180,6 +184,11 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       Asset
     ),
     (
+      missingFieldsAttributeValue(Asset, childCount),
+      "'childCount': missing",
+      Asset
+    ),
+    (
       invalidNumericField(fileSize, File),
       "'fileSize': not of type: 'Number' was 'DynString(1)'",
       File
@@ -206,7 +215,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     ),
     (
       invalidTypeAttributeValue,
-      "'batchId': missing, 'id': missing, 'name': missing, 'sortOrder': missing, 'fileSize': missing, 'checksum_sha256': missing, 'fileExtension': missing, 'type': missing, 'representationType': missing, 'representationSuffix': missing",
+      "'batchId': missing, 'id': missing, 'name': missing, 'sortOrder': missing, 'fileSize': missing, 'checksum_sha256': missing, 'fileExtension': missing, 'type': missing, 'representationType': missing, 'representationSuffix': missing, 'childCount': missing",
       File
     ),
     (
@@ -418,7 +427,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       List(originalFilesUuid),
       List(originalMetadataFilesUuid),
       true,
-      Nil
+      Nil,
+      1
     )
     val res = assetTableFormat.write(dynamoTable)
     val resultMap = res.toAttributeValue.m().asScala
@@ -585,7 +595,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       List(originalFilesUuid),
       List(originalMetadataFilesUuid),
       ingestedPreservica,
-      identifiers
+      identifiers,
+      1
     )
   }
 
@@ -608,7 +619,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       PreservationRepresentationType,
       1,
       ingestedPreservica,
-      List(Identifier("FileIdentifier1", "FileIdentifier1Value"))
+      List(Identifier("FileIdentifier1", "FileIdentifier1Value")),
+      1
     )
   }
 
@@ -621,7 +633,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       ArchiveFolder,
       Option(title),
       Option(description),
-      Nil
+      Nil,
+      1
     )
   }
 
@@ -634,6 +647,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       ContentFolder,
       Option(title),
       Option(description),
-      Nil
+      Nil,
+      1
     )
 }

--- a/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
+++ b/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
@@ -189,6 +189,16 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       Asset
     ),
     (
+      invalidNumericField(childCount, File),
+      "'childCount': not of type: 'Number' was 'DynString(1)'",
+      File
+    ),
+    (
+      invalidNumericValue(childCount, File),
+      "'childCount': could not be converted to desired type: java.lang.RuntimeException: Cannot parse NaN for field childCount into int",
+      File
+    ),
+    (
       invalidNumericField(fileSize, File),
       "'fileSize': not of type: 'Number' was 'DynString(1)'",
       File

--- a/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/XMLCreatorTest.scala
+++ b/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/XMLCreatorTest.scala
@@ -155,7 +155,8 @@ class XMLCreatorTest extends AnyFlatSpec {
     List(UUID.fromString("dec2b921-20e3-41e8-a299-f3cbc13131a2")),
     List(UUID.fromString("3f42e3f2-fffe-4fe9-87f7-262e95b86d75")),
     true,
-    List(Identifier("Test2", "testIdentifier2"), Identifier("Test", "testIdentifier"), Identifier("UpstreamSystemReference", "testSystemRef"))
+    List(Identifier("Test2", "testIdentifier2"), Identifier("Test", "testIdentifier"), Identifier("UpstreamSystemReference", "testSystemRef")),
+    1
   )
   val uuids: List[UUID] = List(UUID.fromString("a814ee41-89f4-4975-8f92-303553fe9a02"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
   val representationTypes: List[(FileRepresentationType, Int)] = List((PreservationRepresentationType, 1), (AccessRepresentationType, 1))
@@ -175,7 +176,8 @@ class XMLCreatorTest extends AnyFlatSpec {
       representationTypes(suffix)._1,
       representationTypes(suffix)._2,
       true,
-      List(Identifier("Test2", "testIdentifier4"), Identifier("Test", "testIdentifier3"), Identifier("UpstreamSystemReference", "testSystemRef2"))
+      List(Identifier("Test2", "testIdentifier4"), Identifier("Test", "testIdentifier3"), Identifier("UpstreamSystemReference", "testSystemRef2")),
+      1
     )
   }
 

--- a/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/testUtils/ExternalServicesTestUtils.scala
+++ b/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/testUtils/ExternalServicesTestUtils.scala
@@ -155,6 +155,9 @@ class ExternalServicesTestUtils(dynamoServer: WireMockServer, s3Server: WireMock
        |      "sortOrder": {
        |        "N": "1"
        |      },
+       |      "childCount": {
+       |        "N": "0"
+       |      },
        |      "id": {
        |        "S": "$childIdDocx"
        |      },
@@ -216,6 +219,9 @@ class ExternalServicesTestUtils(dynamoServer: WireMockServer, s3Server: WireMock
        |      },
        |      "sortOrder": {
        |        "N": "2"
+       |      },
+       |      "childCount": {
+       |        "N": "0"
        |      },
        |      "id": {
        |        "S": "$childIdJson"
@@ -288,6 +294,9 @@ class ExternalServicesTestUtils(dynamoServer: WireMockServer, s3Server: WireMock
        |        },
        |        "batchId": {
        |          "S": "$batchId"
+       |        },
+       |        "childCount": {
+       |          "N": "0"
        |        },
        |        "transferringBody": {
        |          "S": "Test Transferring Body"

--- a/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/ingestassetreconciler/testUtils/ExternalServicesTestUtils.scala
+++ b/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/ingestassetreconciler/testUtils/ExternalServicesTestUtils.scala
@@ -87,6 +87,9 @@ class ExternalServicesTestUtils(dynamoServer: WireMockServer) extends AnyFlatSpe
        |      "sortOrder": {
        |        "N": "1"
        |      },
+       |      "childCount": {
+       |        "N": "0"
+       |      },
        |      "id": {
        |        "S": "$childIdDocx"
        |      },
@@ -151,6 +154,9 @@ class ExternalServicesTestUtils(dynamoServer: WireMockServer) extends AnyFlatSpe
        |      },
        |      "sortOrder": {
        |        "N": "2"
+       |      },
+       |      "childCount": {
+       |        "N": "0"
        |      },
        |      "id": {
        |        "S": "$childIdJson"
@@ -223,6 +229,9 @@ class ExternalServicesTestUtils(dynamoServer: WireMockServer) extends AnyFlatSpe
        |        },
        |        "batchId": {
        |          "S": "$batchId"
+       |        },
+       |        "childCount": {
+       |          "N": "0"
        |        },
        |        "transferringBody": {
        |          "S": "Test Transferring Body"

--- a/ingest-find-existing-asset/src/test/scala/uk/gov/nationalarchives/ingestfindexistingasset/testUtils/ExternalServicesTestUtils.scala
+++ b/ingest-find-existing-asset/src/test/scala/uk/gov/nationalarchives/ingestfindexistingasset/testUtils/ExternalServicesTestUtils.scala
@@ -93,6 +93,9 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
        |        "digitalAssetSubtype": {
        |          "S": "digitalAssetSubtype"
        |        },
+       |        "childCount": {
+       |          "N": "0"
+       |        },
        |        "originalFiles": {
        |          "L": [
        |            {

--- a/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/LambdaTest.scala
+++ b/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/LambdaTest.scala
@@ -98,6 +98,9 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |      },
        |      "batchId": {
        |        "S": "$batchId"
+       |      },
+       |      "childCount": {
+       |        "N": "0"
        |      }
        |    },
        |    {
@@ -115,6 +118,9 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |      },
        |      "batchId": {
        |        "S": "$batchId"
+       |      },
+       |      "childCount": {
+       |        "N": "0"
        |      },
        |      "transferringBody": {
        |        "S": "transferringBody"
@@ -168,6 +174,9 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |        },
        |        "batchId": {
        |          "S": "$batchId"
+       |        },
+       |        "childCount": {
+       |          "N": "0"
        |        },
        |        "id_Code": {
        |          "S": "Code"

--- a/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/XMLCreatorTest.scala
+++ b/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/XMLCreatorTest.scala
@@ -108,7 +108,8 @@ class XMLCreatorTest extends AnyFlatSpec {
     ArchiveFolder,
     Option("title"),
     Option("description"),
-    Nil
+    Nil,
+    1
   )
   val assetUuids: List[UUID] = List(UUID.fromString("a814ee41-89f4-4975-8f92-303553fe9a02"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
   val folderUuids: List[UUID] = List(UUID.fromString("7fcd94a9-be3f-456d-875f-bc697f7ed106"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))

--- a/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/testUtils/ExternalServicesTestUtils.scala
+++ b/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/testUtils/ExternalServicesTestUtils.scala
@@ -44,7 +44,8 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
         ArchiveFolder,
         Some("mock title_1"),
         Some("mock description_1"),
-        List(DynamoIdentifier("Code", "code"))
+        List(DynamoIdentifier("Code", "code")),
+        1
       ),
     UUID.fromString("e88e433a-1f3e-48c5-b15f-234c0e663c27") -> ArchiveFolderDynamoTable(
       "batchId",
@@ -54,7 +55,8 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
       ArchiveFolder,
       Some("mock title_1_1"),
       Some("mock description_1_1"),
-      List(DynamoIdentifier("Code", "code"))
+      List(DynamoIdentifier("Code", "code")),
+      1
     ),
     UUID.fromString("93f5a200-9ee7-423d-827c-aad823182ad2") -> ArchiveFolderDynamoTable(
       "batchId",
@@ -64,7 +66,8 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
       ArchiveFolder,
       Some("mock title_1_1_1"),
       Some("mock description_1_1_1"),
-      List(DynamoIdentifier("Code", "code"))
+      List(DynamoIdentifier("Code", "code")),
+      1
     )
   )
 


### PR DESCRIPTION
DR2-1709 Add childCount to Dynamo case classes

This allows us to read the childCount out of Dynamo. The ticket says that this should be on all rows so I've made it mandatory.
