### PR TITLE
DR2-1752 Handle skipIngest in folder creator.

### DIFF
--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormatters.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormatters.scala
@@ -81,6 +81,7 @@ object DynamoFormatters {
   val representationSuffix = "representationSuffix"
   val ingestedPreservica = "ingested_PS"
   val childCount = "childCount"
+  val skipIngest = "skipIngest"
 
   given filesTablePkFormat: Typeclass[FilesTablePartitionKey] = deriveDynamoFormat[FilesTablePartitionKey]
   given lockTablePkFormat: Typeclass[LockTablePartitionKey] = deriveDynamoFormat[LockTablePartitionKey]
@@ -131,7 +132,8 @@ object DynamoFormatters {
       representationSuffix: ValidatedField[Int],
       ingestedPreservica: Option[String],
       identifiers: List[Identifier],
-      childCount: ValidatedField[Int]
+      childCount: ValidatedField[Int],
+      skipIngest: ValidatedField[Boolean]
   )
 
   case class ArchiveFolderDynamoTable(
@@ -175,7 +177,8 @@ object DynamoFormatters {
       originalMetadataFiles: List[UUID],
       ingestedPreservica: Boolean,
       identifiers: List[Identifier],
-      childCount: Int
+      childCount: Int,
+      skipIngest: Boolean
   ) extends DynamoTable
 
   case class FileDynamoTable(

--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoWriteUtils.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoWriteUtils.scala
@@ -46,7 +46,7 @@ object DynamoWriteUtils {
           "originalFiles" -> DynamoValue.fromStrings(assetDynamoTable.originalFiles.map(_.toString)),
           "originalMetadataFiles" -> DynamoValue.fromStrings(assetDynamoTable.originalMetadataFiles.map(_.toString)),
           ingestedPreservica -> DynamoValue.fromString(assetDynamoTable.ingestedPreservica.toString)
-        )
+        ) ++ (if (assetDynamoTable.skipIngest) Map("skipIngest" -> DynamoValue.fromBoolean(assetDynamoTable.skipIngest)) else Map())
     }.toDynamoValue
 
   def writeFileTable(fileDynamoTable: FileDynamoTable): DynamoValue =

--- a/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
+++ b/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
@@ -7,8 +7,8 @@ import org.scalatest.matchers.should.Matchers.*
 import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor1, TableFor3}
 import org.scanamo.*
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
-import software.amazon.awssdk.services.dynamodb.model.AttributeValue.{fromL, fromM, fromN, fromS}
-import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{given, *}
+import software.amazon.awssdk.services.dynamodb.model.AttributeValue.{fromBool, fromL, fromM, fromN, fromS}
+import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{*, given}
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.Type.*
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.FileRepresentationType.*
 
@@ -69,7 +69,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       description -> fromS("testDescription"),
       "id_Test" -> fromS("testIdentifier"),
       "id_Test2" -> fromS("testIdentifier2"),
-      childCount -> fromN("1")
+      childCount -> fromN("1"),
+      skipIngest -> fromBool(false)
     )
   }
 
@@ -123,6 +124,11 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
   def invalidNumericField(fieldName: String, rowType: Type): AttributeValue = {
     buildAttributeValue(populatedFields(rowType) + (fieldName -> fromS("1")))
   }
+
+  def invalidBooleanField(fieldName: String, rowType: Type): AttributeValue = {
+    buildAttributeValue(populatedFields(rowType) + (fieldName -> fromS("true")))
+  }
+
   def invalidNumericValue(fieldName: String, rowType: Type): AttributeValue = buildAttributeValue(
     populatedFields(rowType) + (fieldName -> fromN("NaN"))
   )
@@ -192,6 +198,11 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       invalidNumericField(childCount, File),
       "'childCount': not of type: 'Number' was 'DynString(1)'",
       File
+    ),
+    (
+      invalidBooleanField(skipIngest, Asset),
+      "'skipIngest': not of type: 'Boolean' was 'DynString(true)'",
+      Asset
     ),
     (
       invalidNumericValue(childCount, File),
@@ -317,6 +328,20 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     assetRowInvalidValue.ingestedPreservica should equal(false)
   }
 
+  "assetTableFormat read" should "return the value if skipIngest is present and false otherwise" in {
+    val skipIngestPresentFalse = assetTableFormat.read(buildAttributeValue(allAssetFieldsPopulated)).value
+    skipIngestPresentFalse.skipIngest should equal(false)
+
+    val skipIngestPresentTrue =
+      assetTableFormat.read(buildAttributeValue(allAssetFieldsPopulated + (skipIngest -> fromBool(true)))).value
+
+    skipIngestPresentTrue.skipIngest should equal(true)
+
+    val skipIngestMissing =
+      assetTableFormat.read(buildAttributeValue(allAssetFieldsPopulated.filter(_._1 != skipIngest))).value
+    skipIngestMissing.skipIngest should equal(false)
+  }
+
   "assetTableFormat read" should "return a valid object when all asset fields are populated" in {
     val assetRow = assetTableFormat.read(buildAttributeValue(allAssetFieldsPopulated)).value
 
@@ -388,6 +413,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     resultMap(ingestedPreservica).s() should equal("true")
     resultMap("representationSuffix").n() should equal("1")
     resultMap("id_FileIdentifier1").s() should equal("FileIdentifier1Value")
+
   }
 
   "archiveFolderTableFormat read" should "return a valid object when all folder fields are populated" in {
@@ -438,7 +464,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       List(originalMetadataFilesUuid),
       true,
       Nil,
-      1
+      1,
+      false
     )
     val res = assetTableFormat.write(dynamoTable)
     val resultMap = res.toAttributeValue.m().asScala
@@ -454,8 +481,19 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     resultMap(originalFiles).ss().asScala.toList should equal(List(originalFilesUuid.toString))
     resultMap(originalMetadataFiles).ss().asScala.toList should equal(List(originalMetadataFilesUuid.toString))
     resultMap(ingestedPreservica).s() should equal("true")
-    List(parentPath, title, description, sortOrder, fileSize, checksumSha256, fileExtension, "identifiers")
+    List(parentPath, title, description, sortOrder, fileSize, checksumSha256, fileExtension, "identifiers", skipIngest)
       .forall(resultMap.contains) should be(false)
+  }
+
+  "assetTableFormat write" should "write skipIngest if set to true and not write it otherwise" in {
+    def skipIngestValue(skipIngestValue: Boolean): Option[Boolean] = {
+      val res = assetTableFormat.write(generateAssetDynamoTable(skipIngest = skipIngestValue))
+      val resultMap = res.toAttributeValue.m().asScala
+      resultMap.get(skipIngest).map(_.bool().booleanValue())
+    }
+    skipIngestValue(false).isDefined should be(false)
+    skipIngestValue(true).contains(true) should be(true)
+
   }
 
   "contentFolderTableFormat read" should "return a valid object when all folder fields are populated" in {
@@ -585,7 +623,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       uuid: UUID = UUID.randomUUID(),
       originalFilesUuid: UUID = UUID.randomUUID(),
       originalMetadataFilesUuid: UUID = UUID.randomUUID(),
-      ingestedPreservica: Boolean = true
+      ingestedPreservica: Boolean = true,
+      skipIngest: Boolean = true
   ): AssetDynamoTable = {
 
     val identifiers = List(Identifier("Test1", "Value1"), Identifier("Test2", "Value2"))
@@ -606,7 +645,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       List(originalMetadataFilesUuid),
       ingestedPreservica,
       identifiers,
-      1
+      1,
+      skipIngest
     )
   }
 

--- a/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
+++ b/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
@@ -338,7 +338,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     skipIngestPresentTrue.skipIngest should equal(true)
 
     val skipIngestMissing =
-      assetTableFormat.read(buildAttributeValue(allAssetFieldsPopulated.filter(_._1 != skipIngest))).value
+      assetTableFormat.read(buildAttributeValue(allAssetFieldsPopulated.filter { case (field, _) => field != skipIngest })).value
     skipIngestMissing.skipIngest should equal(false)
   }
 

--- a/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/XMLCreatorTest.scala
+++ b/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/XMLCreatorTest.scala
@@ -153,7 +153,8 @@ class XMLCreatorTest extends AnyFlatSpec {
     List(UUID.fromString("3f42e3f2-fffe-4fe9-87f7-262e95b86d75")),
     true,
     List(Identifier("Test2", "testIdentifier2"), Identifier("Test", "testIdentifier"), Identifier("UpstreamSystemReference", "testSystemRef")),
-    1
+    1,
+    false
   )
   val uuids: List[UUID] = List(UUID.fromString("a814ee41-89f4-4975-8f92-303553fe9a02"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
   val representationTypes: List[(FileRepresentationType, Int)] = List((PreservationRepresentationType, 1), (AccessRepresentationType, 1))

--- a/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/ingestfolderopexcreator/Lambda.scala
+++ b/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/ingestfolderopexcreator/Lambda.scala
@@ -26,7 +26,12 @@ class Lambda extends LambdaRunner[Input, Unit, Config, Dependencies] {
 
   private def toFolderOrAssetTable[T <: DynamoTable](dynamoValue: DynamoValue)(using dynamoFormat: DynamoFormat[T]): Either[DynamoReadError, FolderOrAssetTable] =
     dynamoFormat.read(dynamoValue).map { table =>
-      FolderOrAssetTable(table.batchId, table.id, table.parentPath, table.name, table.`type`, table.title, table.description, table.identifiers)
+      {
+        val skipIngest = table match
+          case asset: AssetDynamoTable => asset.skipIngest
+          case _                       => false
+        FolderOrAssetTable(table.batchId, table.id, table.parentPath, table.name, table.`type`, table.title, table.description, table.identifiers, skipIngest)
+      }
     }
 
   given DynamoFormat[FolderOrAssetTable] = new DynamoFormat[FolderOrAssetTable] {
@@ -72,6 +77,7 @@ class Lambda extends LambdaRunner[Input, Unit, Config, Dependencies] {
     dynamoClient
       .queryItems[FolderOrAssetTable](tableName, gsiName, "batchId" === asset.batchId and "parentPath" === childrenParentPath)
   }
+
   override def handler: (
       Input,
       Config,
@@ -92,13 +98,14 @@ class Lambda extends LambdaRunner[Input, Unit, Config, Dependencies] {
       _ <- IO.raiseWhen(folder.childCount != children.length)(
         new Exception(s"Folder id ${folder.id}: has ${folder.childCount} children in the files table but found ${children.length} children in the Preservation system")
       )
+      childrenWithoutSkip <- IO(children.filterNot(_.skipIngest))
       _ <- IO.fromOption(children.headOption)(new Exception(s"No children found for ${input.id} and ${input.batchId}"))
       _ <- log(s"Fetched ${children.length} children from Dynamo")
 
-      assetRows <- getAssetRowsWithFileSize(dependencies.s3Client, children, config.bucketName, input.executionName)
+      assetRows <- getAssetRowsWithFileSize(dependencies.s3Client, childrenWithoutSkip, config.bucketName, input.executionName)
       _ <- log("File sizes for assets fetched from S3")
 
-      folderRows <- IO.pure(children.filter(child => isFolder(child.`type`)))
+      folderRows <- IO.pure(childrenWithoutSkip.filter(child => isFolder(child.`type`)))
       folderOpex <- dependencies.xmlCreator.createFolderOpex(folder, assetRows, folderRows, folder.identifiers)
       _ <- xmlValidator(PreservicaSchema.OpexMetadataSchema).xmlStringIsValid("""<?xml version="1.0" encoding="UTF-8"?>""" + folderOpex)
       key = generateKey(input.executionName, folder)
@@ -129,7 +136,8 @@ object Lambda {
       `type`: Type,
       title: Option[String],
       description: Option[String],
-      identifiers: List[Identifier]
+      identifiers: List[Identifier],
+      skipIngest: Boolean = false
   )
 
   case class Dependencies(dynamoClient: DADynamoDBClient[IO], s3Client: DAS3Client[IO], xmlCreator: XMLCreator)

--- a/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/LambdaTest.scala
+++ b/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/LambdaTest.scala
@@ -69,7 +69,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
         .willReturn(ok().withBody(queryResponse))
     )
 
-  private def runAndGetBody(skipIngest: Boolean): String = {
+  private def getFolderOpexFromS3Request(skipIngest: Boolean): String = {
     stubBatchGetRequest(dynamoGetResponse())
     stubDynamoQueryRequest(dynamoQueryResponse(skipIngest))
     val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
@@ -341,7 +341,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
       </opex:Properties>
     </opex:OPEXMetadata>
 
-    val body = runAndGetBody(false)
+    val body = getFolderOpexFromS3Request(false)
 
     body should equal(Utility.trim(expectedResponseXML).toString)
   }
@@ -369,7 +369,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
           </opex:Identifiers>
         </opex:Properties>
       </opex:OPEXMetadata>
-    val body: String = runAndGetBody(true)
+    val body: String = getFolderOpexFromS3Request(true)
 
     body should equal(Utility.trim(expectedResponseXML).toString)
   }

--- a/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/LambdaTest.scala
+++ b/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/LambdaTest.scala
@@ -18,7 +18,7 @@ import uk.gov.nationalarchives.ingestfolderopexcreator.Lambda.{Config, Dependenc
 import java.net.URI
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
-import scala.xml.Elem
+import scala.xml.{Elem, Node, Utility, XML}
 
 class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   val dynamoServer = new WireMockServer(9006)
@@ -69,6 +69,20 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
         .willReturn(ok().withBody(queryResponse))
     )
 
+  private def runAndGetBody(skipIngest: Boolean): String = {
+    stubBatchGetRequest(dynamoGetResponse())
+    stubDynamoQueryRequest(dynamoQueryResponse(skipIngest))
+    val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
+    stubPutRequest(opexPath)
+
+    new Lambda().handler(input, config, dependencies).unsafeRunSync()
+
+    val s3Events = s3Server.getAllServeEvents.asScala
+    val s3PutEvent = s3Events.filter(_.getRequest.getMethod == RequestMethod.PUT).head
+    val body = s3PutEvent.getRequest.getBodyAsString.split("\r\n")(1)
+    Utility.trim(XML.loadString(body)).toString
+  }
+
   val folderId: UUID = UUID.fromString("68b1c80b-36b8-4f0f-94d6-92589002d87e")
   val assetId: UUID = UUID.fromString("5edc7a1b-e8c4-4961-a63b-75b2068b69ec")
   val folderParentPath: String = "a/parent/path"
@@ -80,7 +94,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
 
   val emptyDynamoGetResponse: String = s"""{"Responses": {"$tableName": []}}"""
   val emptyDynamoQueryResponse: String = """{"Count": 0, "Items": []}"""
-  val dynamoQueryResponse: String =
+  def dynamoQueryResponse(skipIngest: Boolean = false): String =
     s"""{
        |  "Count": 2,
        |  "Items": [
@@ -137,6 +151,9 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
        |      },
        |      "digitalAssetSubtype": {
        |        "S": "digitalAssetSubtype"
+       |      },
+       |      "skipIngest": {
+       |        "BOOL": $skipIngest
        |      },
        |      "originalFiles": {
        |        "L": [
@@ -237,7 +254,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
 
   "handler" should "return an error if the expected child count does not match" in {
     stubBatchGetRequest(dynamoGetResponse(3))
-    stubDynamoQueryRequest(dynamoQueryResponse)
+    stubDynamoQueryRequest(dynamoQueryResponse())
     val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
     stubPutRequest(opexPath)
 
@@ -289,7 +306,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
 
   "handler" should "upload the opex file to the correct path" in {
     stubBatchGetRequest(dynamoGetResponse())
-    stubDynamoQueryRequest(dynamoQueryResponse)
+    stubDynamoQueryRequest(dynamoQueryResponse())
     val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
     stubPutRequest(opexPath)
 
@@ -299,7 +316,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
     s3CopyRequests.count(_.getRequest.getUrl == opexPath) should equal(1)
   }
 
-  "handler" should "upload the correct body to S3" in {
+  "handler" should "upload the correct body to S3 if skipIngest is false on the asset" in {
     val expectedResponseXML =
       <opex:OPEXMetadata xmlns:opex="http://www.openpreservationexchange.org/opex/v1.2">
       <opex:Transfer>
@@ -323,18 +340,38 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
         </opex:Identifiers>
       </opex:Properties>
     </opex:OPEXMetadata>
-    stubBatchGetRequest(dynamoGetResponse())
-    stubDynamoQueryRequest(dynamoQueryResponse)
-    val opexPath = s"/opex/$executionName/$folderParentPath/$folderId/$folderId.opex"
-    stubPutRequest(opexPath)
 
-    new Lambda().handler(input, config, dependencies).unsafeRunSync()
+    val body = runAndGetBody(false)
 
-    val s3Events = s3Server.getAllServeEvents.asScala
-    val s3PutEvent = s3Events.filter(_.getRequest.getMethod == RequestMethod.PUT).head
-    val body = s3PutEvent.getRequest.getBodyAsString.split("\r\n")(1)
+    body should equal(Utility.trim(expectedResponseXML).toString)
+  }
 
-    body should equal(expectedResponseXML.toString)
+  "handler" should "upload the correct body to S3 if skipIngest is true on the asset" in {
+    val expectedResponseXML =
+      <opex:OPEXMetadata xmlns:opex="http://www.openpreservationexchange.org/opex/v1.2">
+        <opex:Transfer>
+          <opex:SourceID>Test Name</opex:SourceID>
+          <opex:Manifest>
+            <opex:Files/>
+            <opex:Folders>
+              <opex:Folder>
+                {childId}
+              </opex:Folder>
+            </opex:Folders>
+          </opex:Manifest>
+        </opex:Transfer>
+        <opex:Properties>
+          <opex:Title>Test Name</opex:Title>
+          <opex:Description/>
+          <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+          <opex:Identifiers>
+            <opex:Identifier type="Code">Code</opex:Identifier>
+          </opex:Identifiers>
+        </opex:Properties>
+      </opex:OPEXMetadata>
+    val body: String = runAndGetBody(true)
+
+    body should equal(Utility.trim(expectedResponseXML).toString)
   }
 
   "handler" should "return an error if the Dynamo API is unavailable" in {
@@ -348,7 +385,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach {
   "handler" should "return an error if the S3 API is unavailable" in {
     s3Server.stop()
     stubBatchGetRequest(dynamoGetResponse())
-    stubDynamoQueryRequest(dynamoQueryResponse)
+    stubDynamoQueryRequest(dynamoQueryResponse())
     val ex = intercept[Exception] {
       new Lambda().handler(input, config, dependencies).unsafeRunSync()
     }


### PR DESCRIPTION
There's a few changes here.

The DynamoFormatters now add skipIngest to the Asset case classes.
When it's being read, if it's missing, it's false and when it's being
written, if it's false, we don't write it to the table.
This will be rare enough that writing `skipIngest = false` to every
asset row is a bit wasteful.

I've then changed the folder opex creator to filter on skipIngest after
we've done the check on the childCount.
