### PR TITLE
DR2-1793 remove user and secret env vars

### DIFF
--- a/rotate-preservation-system-password/src/main/resources/application.conf
+++ b/rotate-preservation-system-password/src/main/resources/application.conf
@@ -1,3 +1,1 @@
 api-url = ${PRESERVICA_API_URL}
-api-user = ${PRESERVICA_API_USER}
-secret-name = ${PRESERVICA_SECRET_NAME}


### PR DESCRIPTION
This now gets them from the secret

There is a point where we're calling `head` on the map to get the secret
username and password. I'm usually against calling `head` without checks
but in this case there can be only one entry in secrets manager so we're
ok.
