### PR TITLE
DR2-1480 Allow for different departments in the same batch.

### DIFF
--- a/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryService.scala
+++ b/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryService.scala
@@ -60,14 +60,12 @@ class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Str
     } yield formattedAsset
   }
 
-  def getDiscoveryCollectionAssets(series: Option[String]): IO[DepartmentAndSeriesCollectionAssets] = {
-    val department = series.flatMap(_.split(" ").headOption)
+  def getDiscoveryCollectionAssets(potentialSeries: Option[String]): IO[DepartmentAndSeriesCollectionAssets] = {
+    val potentialDepartment = potentialSeries.flatMap(_.split(" ").headOption)
     for {
-      potentialDepartmentDiscoveryAsset <- department.map(getAssetFromDiscoveryApi).sequence
-      potentialSeriesDiscoveryAsset <- series.map(getAssetFromDiscoveryApi).sequence
-    } yield {
-      DepartmentAndSeriesCollectionAssets(potentialDepartmentDiscoveryAsset, potentialSeriesDiscoveryAsset)
-    }
+      potentialDepartmentDiscoveryAsset <- potentialDepartment.traverse(getAssetFromDiscoveryApi)
+      potentialSeriesDiscoveryAsset <- potentialSeries.traverse(getAssetFromDiscoveryApi)
+    } yield DepartmentAndSeriesCollectionAssets(potentialDepartmentDiscoveryAsset, potentialSeriesDiscoveryAsset)
   }
   def getDepartmentAndSeriesItems(batchId: String, departmentAndSeriesAssets: DepartmentAndSeriesCollectionAssets): DepartmentAndSeriesTableItems = {
     def generateTableItem(asset: DiscoveryCollectionAsset): Map[String, Value] =

--- a/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryService.scala
+++ b/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryService.scala
@@ -8,7 +8,6 @@ import sttp.client3.{SttpBackend, UriContext, basicRequest}
 import sttp.client3.circe.*
 import sttp.client3.*
 import uk.gov.nationalarchives.ingestmapper.DiscoveryService._
-import uk.gov.nationalarchives.ingestmapper.Lambda.Input
 import uk.gov.nationalarchives.ingestmapper.MetadataService._
 import uk.gov.nationalarchives.ingestmapper.MetadataService.Type._
 import io.circe.generic.auto._
@@ -61,10 +60,19 @@ class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Str
     } yield formattedAsset
   }
 
-  def getDepartmentAndSeriesItems(input: Input): IO[DepartmentAndSeriesTableItems] = {
+  def getDiscoveryCollectionAssets(series: Option[String]): IO[DepartmentAndSeriesCollectionAssets] = {
+    val department = series.flatMap(_.split(" ").headOption)
+    for {
+      potentialDepartmentDiscoveryAsset <- department.map(getAssetFromDiscoveryApi).sequence
+      potentialSeriesDiscoveryAsset <- series.map(getAssetFromDiscoveryApi).sequence
+    } yield {
+      DepartmentAndSeriesCollectionAssets(potentialDepartmentDiscoveryAsset, potentialSeriesDiscoveryAsset)
+    }
+  }
+  def getDepartmentAndSeriesItems(batchId: String, departmentAndSeriesAssets: DepartmentAndSeriesCollectionAssets): DepartmentAndSeriesTableItems = {
     def generateTableItem(asset: DiscoveryCollectionAsset): Map[String, Value] =
       Map(
-        "batchId" -> Str(input.batchId),
+        "batchId" -> Str(batchId),
         "id" -> Str(randomUuidGenerator().toString),
         "name" -> Str(asset.citableReference),
         "type" -> Str(ArchiveFolder.toString),
@@ -72,35 +80,35 @@ class DiscoveryService(discoveryBaseUrl: String, backend: SttpBackend[IO, Fs2Str
         "description" -> Str(asset.scopeContent.description)
       )
 
-    for {
-      potentialDepartmentDiscoveryAsset <- input.department.map(getAssetFromDiscoveryApi).sequence
-      potentialSeriesDiscoveryAsset <- input.series.map(getAssetFromDiscoveryApi).sequence
-    } yield {
-      val departmentTableEntryMap = potentialDepartmentDiscoveryAsset
-        .map(generateTableItem)
-        .map(jsonMap => jsonMap ++ Map("id_Code" -> jsonMap("name")))
-        .getOrElse(
-          Map(
-            "batchId" -> Str(input.batchId),
-            "id" -> Str(randomUuidGenerator().toString),
-            "name" -> Str("Unknown"),
-            "type" -> Str(ArchiveFolder.toString)
-          )
+    val departmentTableEntryMap = departmentAndSeriesAssets.potentialDepartmentCollectionAsset
+      .map(generateTableItem)
+      .map(jsonMap => jsonMap ++ Map("id_Code" -> jsonMap("name")))
+      .getOrElse(
+        Map(
+          "batchId" -> Str(batchId),
+          "id" -> Str(randomUuidGenerator().toString),
+          "name" -> Str("Unknown"),
+          "type" -> Str(ArchiveFolder.toString)
         )
+      )
 
-      val seriesTableEntryOpt = potentialSeriesDiscoveryAsset
-        .map(generateTableItem)
-        .map(jsonMap => jsonMap ++ Map("parentPath" -> departmentTableEntryMap("id"), "id_Code" -> jsonMap("name")))
-        .map(Obj.from)
+    val seriesTableEntryOpt = departmentAndSeriesAssets.potentialSeriesCollectionAsset
+      .map(generateTableItem)
+      .map(jsonMap => jsonMap ++ Map("parentPath" -> departmentTableEntryMap("id"), "id_Code" -> jsonMap("name")))
+      .map(Obj.from)
 
-      DepartmentAndSeriesTableItems(Obj.from(departmentTableEntryMap), seriesTableEntryOpt)
-    }
+    DepartmentAndSeriesTableItems(Obj.from(departmentTableEntryMap), seriesTableEntryOpt)
+
   }
 }
 object DiscoveryService {
   case class DiscoveryScopeContent(description: String)
   case class DiscoveryCollectionAsset(citableReference: String, scopeContent: DiscoveryScopeContent, title: String)
   case class DiscoveryCollectionAssetResponse(assets: List[DiscoveryCollectionAsset])
+  case class DepartmentAndSeriesCollectionAssets(
+      potentialDepartmentCollectionAsset: Option[DiscoveryCollectionAsset],
+      potentialSeriesCollectionAsset: Option[DiscoveryCollectionAsset]
+  )
 
   def apply(discoveryUrl: String, randomUuidGenerator: () => UUID): IO[DiscoveryService] = HttpClientFs2Backend.resource[IO]().use { backend =>
     IO.pure(new DiscoveryService(discoveryUrl, backend, randomUuidGenerator))

--- a/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/MetadataService.scala
+++ b/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/MetadataService.scala
@@ -67,7 +67,7 @@ class MetadataService(s3: DAS3Client[IO], discoveryService: DiscoveryService) {
           val json = read(metadataJson)
           val jsonArr = json.arr.toList
           val topLevelObjects = jsonArr.filter(_.parentId.isEmpty)
-          val topLevelItemToDepartmentSeries: IO[Map[UUID, DepartmentAndSeriesTableItems]] = topLevelObjects
+          val topLevelIdsToDepartmentSeries: IO[Map[UUID, DepartmentAndSeriesTableItems]] = topLevelObjects
             .groupBy(_.series)
             .view
             .mapValues(_.map(_.id))
@@ -81,9 +81,9 @@ class MetadataService(s3: DAS3Client[IO], discoveryService: DiscoveryService) {
             .sequence
             .map(_.flatten.toMap)
           Stream.evals {
-            topLevelItemToDepartmentSeries.map { itemToDepartmentSeries =>
+            topLevelIdsToDepartmentSeries.map { itemToDepartmentSeries =>
               val parentPaths = getParentPaths(json, itemToDepartmentSeries)
-              val updatedJson = json.arr.toList.map { metadataEntry =>
+              val updatedJson = jsonArr.map { metadataEntry =>
                 val id = UUID.fromString(metadataEntry("id").str)
                 val name = metadataEntry("name").str
                 val parentPath = parentPaths(id)

--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessor.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessor.scala
@@ -110,7 +110,7 @@ class FileProcessor(
     val fileTitle = fileInfo.fileName.split('.').dropRight(1).mkString(".")
     val folderId = uuidGenerator()
     val assetId = UUID.fromString(tdrUuid)
-    val folderMetadataObject = FolderMetadataObject(folderId, None, potentialFolderTitle, folderName, folderMetadataIdFields)
+    val folderMetadataObject = FolderMetadataObject(folderId, None, potentialFolderTitle, folderName, potentialSeries, folderMetadataIdFields)
     val assetMetadataObject =
       AssetMetadataObject(
         assetId,
@@ -234,10 +234,17 @@ object FileProcessor {
       skipSeriesLookup <- c.getOrElse("skipSeriesLookup")(false)
     } yield TREInputParameters(status, reference, skipSeriesLookup, s3Bucket, s3Key)
   given Encoder[MetadataObject] = {
-    case FolderMetadataObject(id, parentId, title, name, folderMetadataIdFields) =>
-      jsonFromMetadataObject(id, parentId, title, Type.ArchiveFolder, name).deepMerge {
-        Json.fromFields(convertIdFieldsToJson(folderMetadataIdFields))
-      }
+    case FolderMetadataObject(id, parentId, title, name, potentialSeries, folderMetadataIdFields) =>
+      jsonFromMetadataObject(id, parentId, title, Type.ArchiveFolder, name)
+        .deepMerge {
+          Json.fromFields(convertIdFieldsToJson(folderMetadataIdFields))
+        }
+        .deepMerge {
+          Json
+            .obj(
+              ("series", potentialSeries.map(Json.fromString).getOrElse(Json.Null))
+            )
+        }
     case AssetMetadataObject(
           id,
           parentId,
@@ -328,6 +335,7 @@ object FileProcessor {
       parentId: Option[UUID],
       title: Option[String],
       name: String,
+      potentialSeries: Option[String],
       idFields: List[IdField] = Nil
   ) extends MetadataObject
 

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessorTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessorTest.scala
@@ -366,7 +366,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
               val fileName = treFileName.split('.').dropRight(1).mkString(".")
               val folderTitle = if titleExpected then Option(expectedFolderTitle) else None
               val folder =
-                FolderMetadataObject(folderId, None, folderTitle, expectedFolderName, updatedIdFields)
+                FolderMetadataObject(folderId, None, folderTitle, expectedFolderName, series, updatedIdFields)
               val asset =
                 AssetMetadataObject(
                   assetId,

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
@@ -300,6 +300,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
           None,
           Option("test"),
           "https://example.com/id/court/2023/",
+          Option("TEST SERIES"),
           if potentialCite.isDefined then idFields :+ IdField("URI", "https://example.com/id/court/2023/") else idFields
         )
       val metadataList: List[MetadataObject] =


### PR DESCRIPTION
The way this works is roughly

* parsed-court-document-handler adds series to the top level folder.
* ingest-mapper gets all of the top level folders, reads the series,
  and creates a de-duped list.
* The department is found with `series.split(" ").head`
* The department and series are found from the discovery API.
* Based on the parent top level folder, the `${department.id}/${series.id} prefix is prepended to the parent path.
* This is written to Dynamo along with the series.
* Everything downstream runs off parentPath so this should just work.

This has not been tested on integration because I can't get into AWS so there may be some small tweaks but this is ready for review.