### PR TITLE
DR2-1802 Use correlation id as parent message id.

### DIFF
--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormatters.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormatters.scala
@@ -86,6 +86,7 @@ object DynamoFormatters {
   val childCount = "childCount"
   val skipIngest = "skipIngest"
   val location = "location"
+  val correlationId = "correlationId"
 
   given filesTablePkFormat: Typeclass[FilesTablePrimaryKey] = new DynamoFormat[FilesTablePrimaryKey]:
     override def read(av: DynamoValue): Either[DynamoReadError, FilesTablePrimaryKey] = {
@@ -168,7 +169,8 @@ object DynamoFormatters {
       identifiers: List[Identifier],
       childCount: ValidatedField[Int],
       skipIngest: ValidatedField[Boolean],
-      location: ValidatedField[URI]
+      location: ValidatedField[URI],
+      correlationId: Option[String]
   )
 
   case class ArchiveFolderDynamoTable(
@@ -214,7 +216,8 @@ object DynamoFormatters {
       ingestedCustodialCopy: Boolean,
       identifiers: List[Identifier],
       childCount: Int,
-      skipIngest: Boolean
+      skipIngest: Boolean,
+      correlationId: Option[String]
   ) extends DynamoTable
 
   case class FileDynamoTable(

--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoReadUtils.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoReadUtils.scala
@@ -70,7 +70,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
     identifiers,
     getNumber(childCount, _.toInt),
     getBoolean(skipIngest),
-    stringToScalaType[URI](location, getPotentialStringValue(location), URI.create)
+    stringToScalaType[URI](location, getPotentialStringValue(location), URI.create),
+    getPotentialStringValue(correlationId)
   )
 
   private def stringToType(potentialTypeString: Option[String]): ValidatedNel[InvalidProperty, Type] =
@@ -292,7 +293,8 @@ class DynamoReadUtils(folderRowAsMap: Map[String, AttributeValue]) {
           allValidatedFileTableFields.ingestedCustodialCopy.contains("true"),
           allValidatedFileTableFields.identifiers,
           childCount,
-          skipIngest
+          skipIngest,
+          allValidatedFileTableFields.correlationId
         )
     }.toEither
       .left

--- a/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoWriteUtils.scala
+++ b/dynamo-formatters/src/main/scala/uk/gov/nationalarchives/dynamoformatters/DynamoWriteUtils.scala
@@ -48,6 +48,7 @@ object DynamoWriteUtils {
           ingestedPreservica -> DynamoValue.fromString(assetDynamoTable.ingestedPreservica.toString),
           ingestedCustodialCopy -> DynamoValue.fromString(assetDynamoTable.ingestedCustodialCopy.toString)
         ) ++ (if (assetDynamoTable.skipIngest) Map("skipIngest" -> DynamoValue.fromBoolean(assetDynamoTable.skipIngest)) else Map())
+        ++ assetDynamoTable.correlationId.map(id => Map(correlationId -> DynamoValue.fromString(id))).getOrElse(Map())
     }.toDynamoValue
 
   def writeFileTable(fileDynamoTable: FileDynamoTable): DynamoValue =

--- a/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
+++ b/dynamo-formatters/src/test/scala/uk/gov/nationalarchives/dynamoformatters/DynamoFormattersTest.scala
@@ -74,7 +74,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       "id_Test" -> fromS("testIdentifier"),
       "id_Test2" -> fromS("testIdentifier2"),
       childCount -> fromN("1"),
-      skipIngest -> fromBool(false)
+      skipIngest -> fromBool(false),
+      correlationId -> fromS("correlationId")
     )
   }
 
@@ -382,6 +383,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     assetRow.originalMetadataFiles should equal(List(UUID.fromString("3f42e3f2-fffe-4fe9-87f7-262e95b86d75")))
     assetRow.title.get should equal("testTitle")
     assetRow.description.get should equal("testDescription")
+    assetRow.correlationId.get should equal("correlationId")
     assetRow.identifiers.sortBy(_.identifierName) should equal(
       List(Identifier("Test2", "testIdentifier2"), Identifier("Test", "testIdentifier")).sortBy(_.identifierName)
     )
@@ -491,7 +493,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       true,
       Nil,
       1,
-      false
+      false,
+      None
     )
     val res = assetTableFormat.write(dynamoTable)
     val resultMap = res.toAttributeValue.m().asScala
@@ -508,7 +511,7 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
     resultMap(originalMetadataFiles).ss().asScala.toList should equal(List(originalMetadataFilesUuid.toString))
     resultMap(ingestedPreservica).s() should equal("true")
     resultMap(ingestedCustodialCopy).s() should equal("true")
-    List(parentPath, title, description, sortOrder, fileSize, checksumSha256, fileExtension, "identifiers", skipIngest)
+    List(parentPath, title, description, sortOrder, fileSize, checksumSha256, fileExtension, "identifiers", skipIngest, correlationId)
       .forall(resultMap.contains) should be(false)
   }
 
@@ -677,7 +680,8 @@ class DynamoFormattersTest extends AnyFlatSpec with TableDrivenPropertyChecks wi
       true,
       identifiers,
       1,
-      skipIngest
+      skipIngest,
+      Option("correlationId")
     )
   }
 

--- a/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/XMLCreatorTest.scala
+++ b/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/XMLCreatorTest.scala
@@ -156,7 +156,8 @@ class XMLCreatorTest extends AnyFlatSpec {
     true,
     List(Identifier("Test2", "testIdentifier2"), Identifier("Test", "testIdentifier"), Identifier("UpstreamSystemReference", "testSystemRef")),
     1,
-    false
+    false,
+    None
   )
   val uuids: List[UUID] = List(UUID.fromString("a814ee41-89f4-4975-8f92-303553fe9a02"), UUID.fromString("9ecbba86-437f-42c6-aeba-e28b678bbf4c"))
   val representationTypes: List[(FileRepresentationType, Int)] = List((PreservationRepresentationType, 1), (AccessRepresentationType, 1))

--- a/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
+++ b/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
@@ -27,7 +27,7 @@ class Lambda extends LambdaRunner[DynamodbEvent, Unit, Config, Dependencies]:
       FilesTablePrimaryKey(FilesTablePartitionKey(row.id), FilesTableSortKey(row.batchId))
 
     def sendOutputMessage(asset: AssetDynamoTable, messageType: MessageType): IO[Unit] = {
-      val message = OutputMessage(OutputProperties(dependencies.uuidGenerator(), None, dependencies.instantGenerator(), messageType), OutputParameters(asset.id))
+      val message = OutputMessage(OutputProperties(dependencies.uuidGenerator(), asset.correlationId, dependencies.instantGenerator(), messageType), OutputParameters(asset.id))
       dependencies.daSnsClient.publish(config.topicArn)(message :: Nil).map(_ => ())
     }
 
@@ -191,6 +191,6 @@ object Lambda:
   given Encoder[OutputParameters] = deriveEncoder[OutputParameters]
   given Encoder[OutputMessage] = deriveEncoder[OutputMessage]
 
-  case class OutputProperties(messageId: UUID, parentMessageId: Option[UUID], timestamp: Instant, `type`: MessageType)
+  case class OutputProperties(messageId: UUID, parentMessageId: Option[String], timestamp: Instant, `type`: MessageType)
   case class OutputParameters(assetId: UUID)
   case class OutputMessage(properties: OutputProperties, parameters: OutputParameters)

--- a/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
+++ b/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
@@ -29,7 +29,8 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
   val fileBOne: DynamoRow = DynamoRow(UUID.randomUUID, "B", File, Option(s"${folderB.id}/${assetB.id}"))
   val fileBTwo: DynamoRow = DynamoRow(UUID.randomUUID, "B", File, Option(s"${folderB.id}/${assetB.id}"))
 
-  def outputBuilder(id: UUID, messageType: MessageType): OutputMessage = OutputMessage(OutputProperties(messageId, None, instant, messageType), OutputParameters(id))
+  def outputBuilder(id: UUID, messageType: MessageType): OutputMessage =
+    OutputMessage(OutputProperties(messageId, Option("correlationId"), instant, messageType), OutputParameters(id))
 
   val handlerOutputsTable: TableFor4[String, List[DynamoRow], DynamoRow, List[OutputMessage]] = Table(
     ("title", "rowsInTable", "newRowInput", "expectedOutput"),

--- a/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/Utils.scala
+++ b/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/Utils.scala
@@ -53,7 +53,8 @@ object Utils {
       row.ingestedCustodialCopy,
       Nil,
       2,
-      row.skipIngest
+      row.skipIngest,
+      Option("correlationId")
     )
 
     def createFile(): FileDynamoTable = FileDynamoTable(


### PR DESCRIPTION
This will always be empty for now because the judgments don't use it but
it will be useful for TDR transfers.
