### PR TITLE
DR2-1832 Use unknown when series is null

### DIFF
--- a/ingest-mapper/README.md
+++ b/ingest-mapper/README.md
@@ -13,6 +13,7 @@ The lambda:
 * Downloads the metadata file from the `metadataPackage` location and parses it.
 * Gets a list of series names from the metadata json. Do `series.split(" ").head` to get the department.
 * For each series and department pair, get the title and description for department and series from Discovery. This is run through the XSLT in `src/main/resources/transform.xsl` to replace the EAD tags with newlines.
+* If the series is `Unknown`, it will create a hierarchy of `Unknown/Court Documents (court unknown)` or `Unknown/Court Documents (court not matched)` depending on the title of the top level folder.
 * Creates a ujson Obj with the department and series output and the metadata json. We use a generic `Obj` because we will eventually have to handle fields we don't know about in advance.
 * Updates dynamo with the values
 * Writes the state data for the next step function step with this format:

--- a/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/MetadataService.scala
+++ b/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/MetadataService.scala
@@ -73,10 +73,10 @@ class MetadataService(s3: DAS3Client[IO], discoveryService: DiscoveryService) {
             .view
             .mapValues(_.map(_.id))
             .toMap
-            .map { case (series, parentIds) =>
+            .map { case (potentialSeries, parentIds) =>
               val collectionAssets =
-                if series.contains("Unknown") then IO.pure(DepartmentAndSeriesCollectionAssets(None, None))
-                else discoveryService.getDiscoveryCollectionAssets(series)
+                if potentialSeries.contains("Unknown") then IO.pure(DepartmentAndSeriesCollectionAssets(None, None))
+                else discoveryService.getDiscoveryCollectionAssets(potentialSeries)
               collectionAssets.map { assets =>
                 parentIds.map(parentId => parentId -> discoveryService.getDepartmentAndSeriesItems(input.batchId, assets))
               }

--- a/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
+++ b/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
@@ -64,19 +64,20 @@ class LambdaTest extends AnyFlatSpec with MockitoSugar with BeforeAndAfterEach {
     val tableRequestItems = dynamoRequestBodies.head.RequestItems.test
 
     tableRequestItems.length should equal(11)
-    case class TestResponses(response: NetworkResponse, uuidIndices: List[Int], series: String)
+    case class TestResponses(dynamoResponse: DynamoResponse, uuidIndices: List[Int], series: String)
     List(
       TestResponses(responseTwo, List(2, 3), "Unknown"),
       TestResponses(responseOne, List(0, 1), "A 1")
     ).foreach { testResponse =>
-      val (folderIdentifier, assetIdentifier, docxIdentifier, metadataIdentifier, originalFiles, originalMetadataFiles) = testResponse.response
+      val (folderIdentifier, assetIdentifier, docxIdentifier, metadataIdentifier, originalFiles, originalMetadataFiles) = testResponse.dynamoResponse
       val departmentUuid = UUID.fromString(uuids(testResponse.uuidIndices.head))
       val seriesUuid = UUID.fromString(uuids(testResponse.uuidIndices.last))
       val expectedDepartment = testResponse.series.split(" ").head
-      val expectedTitle = if testResponse.series == "Unknown" then "" else s"Test Title $expectedDepartment"
-      val expectedIdCode = if testResponse.series == "Unknown" then "" else expectedDepartment
-      val expectedDescription = if testResponse.series == "Unknown" then "" else s"TestDescription$expectedDepartment with 0"
-      val topFolderPath = if testResponse.series == "Unknown" then departmentUuid.toString else s"$departmentUuid/$seriesUuid"
+      val seriesUnknown = testResponse.series == "Unknown"
+      val expectedTitle = if seriesUnknown then "" else s"Test Title $expectedDepartment"
+      val expectedIdCode = if seriesUnknown then "" else expectedDepartment
+      val expectedDescription = if seriesUnknown then "" else s"TestDescription$expectedDepartment with 0"
+      val topFolderPath = if seriesUnknown then departmentUuid.toString else s"$departmentUuid/$seriesUuid"
 
       checkDynamoItems(
         tableRequestItems,

--- a/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/MetadataServiceTest.scala
+++ b/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/MetadataServiceTest.scala
@@ -86,7 +86,8 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
                 "type" -> "ArchiveFolder",
                 "title" -> s"$tableType Title",
                 "description" -> s"$tableType Description",
-                "ttl" -> 1712707200
+                "ttl" -> 1712707200,
+                "series" -> seriesIdOpt.map(_.toString).getOrElse("Unknown")
               )
             }
 
@@ -103,7 +104,7 @@ class MetadataServiceTest extends AnyFlatSpec with MockitoSugar with TableDriven
           val originalFileId = UUID.randomUUID()
           val originalMetadataFileId = UUID.randomUUID()
           val metadata =
-            s"""[{"id":"$folderId","parentId":null,"title":"TestTitle","type":"ArchiveFolder","name":"TestName","fileSize":null},
+            s"""[{"id":"$folderId","parentId":null,"title":"TestTitle","type":"ArchiveFolder","name":"TestName","fileSize":null, "series": null},
            |{"id":"$assetId","parentId":"$folderId","title":"TestAssetTitle","type":"Asset","name":"TestAssetName","fileSize":null, "originalFiles" : ["$originalFileId"], "originalMetadataFiles": ["$originalMetadataFileId"], "customMetadataAttribute1": "customMetadataAttributeValue"},
            |{"id":"$fileIdOne","parentId":"$assetId","title":"Test","type":"File","name":"$name","fileSize":1, "checksumSha256": "$name-checksum"},
            |{"id":"$fileIdTwo","parentId":"$assetId","title":"","type":"File","name":"TEST-metadata.json","fileSize":2, "checksumSha256": "metadata-checksum"}]

--- a/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
+++ b/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
@@ -34,9 +34,9 @@ class LambdaTestTestUtils(dynamoServer: WireMockServer, s3Server: WireMockServer
   val config: Config = Config("test", "http://localhost:9015")
   val input: Input = Input("TEST", URI.create(s"s3://$inputBucket/${s3Prefix}metadata.json"))
 
-  type NetworkResponse = (UUID, UUID, UUID, UUID, List[String], List[String])
+  type DynamoResponse = (UUID, UUID, UUID, UUID, List[String], List[String])
 
-  def stubValidNetworkRequests(dynamoTable: String = "test"): (NetworkResponse, NetworkResponse) = {
+  def stubValidNetworkRequests(dynamoTable: String = "test"): (DynamoResponse, DynamoResponse) = {
     val folderIdentifierOne = UUID.randomUUID()
     val folderIdentifierTwo = UUID.randomUUID()
     val assetIdentifierOne = UUID.randomUUID()

--- a/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
+++ b/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
@@ -53,7 +53,7 @@ class LambdaTestTestUtils(dynamoServer: WireMockServer, s3Server: WireMockServer
     val metadata =
       s"""[
          |{"id":"$folderIdentifierOne","parentId":null,"title":"TestTitle","type":"ArchiveFolder","name":"TestName","fileSize":null, "customMetadataAttribute2": "customMetadataValue2", "series": "A 1"},
-         |{"id":"$folderIdentifierTwo","parentId":null,"title":"TestTitle","type":"ArchiveFolder","name":"TestName","fileSize":null, "customMetadataAttribute2": "customMetadataValue2", "series": "B 2"},
+         |{"id":"$folderIdentifierTwo","parentId":null,"title":"TestTitle","type":"ArchiveFolder","name":"TestName","fileSize":null, "customMetadataAttribute2": "customMetadataValue2", "series": null},
          |{
          | "id":"$assetIdentifierOne",
          | "parentId":"$folderIdentifierOne",

--- a/ingest-parsed-court-document-event-handler/README.md
+++ b/ingest-parsed-court-document-event-handler/README.md
@@ -50,7 +50,7 @@ We can also replay the message with the `skipSeriesLookup` parameter
 }
 ```
 
-The lambda doesn't produce an output. It writes files and metadata to S3/
+The lambda doesn't produce an output. It writes files and metadata to S3.
 
 #### metadata.json
 
@@ -112,6 +112,8 @@ The lambda doesn't produce an output. It writes files and metadata to S3/
   }
 ]
 ```
+
+If `skipSeriesLookup` is sent and the series can't be found, the value of `series` in the top level `ArchiveFolder` will be `Unknown` 
 
 [Link to the infrastructure code](https://github.com/nationalarchives/dp-terraform-environments/blob/main/ingest_parsed_court_document_event_handler.tf)
 

--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessor.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessor.scala
@@ -110,7 +110,7 @@ class FileProcessor(
     val fileTitle = fileInfo.fileName.split('.').dropRight(1).mkString(".")
     val folderId = uuidGenerator()
     val assetId = UUID.fromString(tdrUuid)
-    val folderMetadataObject = FolderMetadataObject(folderId, None, potentialFolderTitle, folderName, potentialSeries, folderMetadataIdFields)
+    val folderMetadataObject = FolderMetadataObject(folderId, None, potentialFolderTitle, folderName, potentialSeries.getOrElse("Unknown"), folderMetadataIdFields)
     val assetMetadataObject =
       AssetMetadataObject(
         assetId,
@@ -234,7 +234,7 @@ object FileProcessor {
       skipSeriesLookup <- c.getOrElse("skipSeriesLookup")(false)
     } yield TREInputParameters(status, reference, skipSeriesLookup, s3Bucket, s3Key)
   given Encoder[MetadataObject] = {
-    case FolderMetadataObject(id, parentId, title, name, potentialSeries, folderMetadataIdFields) =>
+    case FolderMetadataObject(id, parentId, title, name, series, folderMetadataIdFields) =>
       jsonFromMetadataObject(id, parentId, title, Type.ArchiveFolder, name)
         .deepMerge {
           Json.fromFields(convertIdFieldsToJson(folderMetadataIdFields))
@@ -242,7 +242,7 @@ object FileProcessor {
         .deepMerge {
           Json
             .obj(
-              ("series", potentialSeries.map(Json.fromString).getOrElse(Json.Null))
+              ("series", Json.fromString(series))
             )
         }
     case AssetMetadataObject(
@@ -335,7 +335,7 @@ object FileProcessor {
       parentId: Option[UUID],
       title: Option[String],
       name: String,
-      potentialSeries: Option[String],
+      series: String,
       idFields: List[IdField] = Nil
   ) extends MetadataObject
 

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessorTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessorTest.scala
@@ -366,7 +366,7 @@ class FileProcessorTest extends AnyFlatSpec with MockitoSugar with TableDrivenPr
               val fileName = treFileName.split('.').dropRight(1).mkString(".")
               val folderTitle = if titleExpected then Option(expectedFolderTitle) else None
               val folder =
-                FolderMetadataObject(folderId, None, folderTitle, expectedFolderName, series, updatedIdFields)
+                FolderMetadataObject(folderId, None, folderTitle, expectedFolderName, series.getOrElse("Unknown"), updatedIdFields)
               val asset =
                 AssetMetadataObject(
                   assetId,

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
@@ -300,7 +300,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
           None,
           Option("test"),
           "https://example.com/id/court/2023/",
-          Option("TEST SERIES"),
+          "TEST SERIES",
           if potentialCite.isDefined then idFields :+ IdField("URI", "https://example.com/id/court/2023/") else idFields
         )
       val metadataList: List[MetadataObject] =


### PR DESCRIPTION
We are getting an error in the ingest mapper when the series is coming back from the document-handler as null.

To fix this, we’re going to stop sending null as the Series. This will allow us to validate the series and stops passing nulls around.

The parsed-court-document-handler will output Unknown with the name as Court Documents (court unknown) if the series is not known.

If the ingest-mapper finds Unknown, it creates the Unknown/Court Documents (court unknown) folder structure.
