### PR TITLE
DR2-1833 Remove department and series from output/sfn input

### DIFF
--- a/ingest-mapper/README.md
+++ b/ingest-mapper/README.md
@@ -7,16 +7,13 @@ The lambda:
 ```json
 {
   "batchId": "batch",
-  "s3Bucket": "bucket",
-  "s3Prefix": "prefix/",
-  "department": "department",
-  "series": "series"
+  "metadataPackage": "s3://metadata-bucket/metadata.json"
 }
 ```
-* Gets the title and description for department and series from Discovery. This is run through the XSLT in `src/main/resources/transform.xsl` to replace the EAD tags with newlines.
-* Parses the metadata json file
-* Parses the manifest file
-* Converts these into ujson Obj classes. This is because we will eventually have to handle fields we don't know about in advance.
+* Downloads the metadata file from the `metadataPackage` location and parses it.
+* Gets a list of series names from the metadata json. Do `series.split(" ").head` to get the department.
+* For each series and department pair, get the title and description for department and series from Discovery. This is run through the XSLT in `src/main/resources/transform.xsl` to replace the EAD tags with newlines.
+* Creates a ujson Obj with the department and series output and the metadata json. We use a generic `Obj` because we will eventually have to handle fields we don't know about in advance.
 * Updates dynamo with the values
 * Writes the state data for the next step function step with this format:
 ```json

--- a/ingest-parsed-court-document-event-handler/README.md
+++ b/ingest-parsed-court-document-event-handler/README.md
@@ -57,6 +57,7 @@ The lambda doesn't produce an output. It writes files and metadata to S3/
 ```json
 [
   {
+    "series": "ABC 123",
     "id_Code": "cite",
     "id_Cite": "cite",
     "id_URI": "https://example.com/id/court/2023/",

--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
@@ -63,7 +63,7 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
 
           _ <- IO.raiseWhen(fileInfo.fileSize == 0)(new Exception(s"File id '${fileInfo.id}' size is 0"))
           metadataPackage = URI.create(s"s3://$outputBucket/$batchRef/metadata.json")
-          departmentSeries <- dependencies.seriesMapper.createDepartmentSeries(
+          departmentAndSeries <- dependencies.seriesMapper.createDepartmentAndSeries(
             parsedUri.flatMap(_.potentialCourt),
             treInput.parameters.skipSeriesLookup
           )
@@ -78,8 +78,8 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
             potentialUri,
             treMetadata,
             fileReference,
-            departmentSeries.potentialDepartment,
-            departmentSeries.potentialSeries,
+            departmentAndSeries.potentialDepartment,
+            departmentAndSeries.potentialSeries,
             tdrUuid
           )
           _ <- fileProcessor.createMetadataJson(metadata, metadataPackage)

--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
@@ -13,6 +13,7 @@ import uk.gov.nationalarchives.DADynamoDBClient.DADynamoDbWriteItemRequest
 import uk.gov.nationalarchives.utils.EventDecoders.given
 import uk.gov.nationalarchives.ingestparsedcourtdocumenteventhandler.FileProcessor.*
 import uk.gov.nationalarchives.ingestparsedcourtdocumenteventhandler.Lambda.Dependencies
+import uk.gov.nationalarchives.ingestparsedcourtdocumenteventhandler.SeriesMapper.*
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{batchId, ioId, message}
 import uk.gov.nationalarchives.utils.LambdaRunner
 import uk.gov.nationalarchives.{DADynamoDBClient, DAS3Client, DASFNClient}
@@ -62,9 +63,7 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
 
           _ <- IO.raiseWhen(fileInfo.fileSize == 0)(new Exception(s"File id '${fileInfo.id}' size is 0"))
           metadataPackage = URI.create(s"s3://$outputBucket/$batchRef/metadata.json")
-          output <- dependencies.seriesMapper.createOutput(
-            metadataPackage,
-            batchRef,
+          departmentSeries <- dependencies.seriesMapper.createDepartmentSeries(
             parsedUri.flatMap(_.potentialCourt),
             treInput.parameters.skipSeriesLookup
           )
@@ -79,8 +78,8 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
             potentialUri,
             treMetadata,
             fileReference,
-            output.department,
-            output.series,
+            departmentSeries.potentialDepartment,
+            departmentSeries.potentialSeries,
             tdrUuid
           )
           _ <- fileProcessor.createMetadataJson(metadata, metadataPackage)
@@ -105,7 +104,7 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
           )
           _ <- logWithFileRef("Written asset to lock table")
 
-          _ <- dependencies.sfn.startExecution(config.sfnArn, output, Option(batchRef))
+          _ <- dependencies.sfn.startExecution(config.sfnArn, Output(batchRef, metadataPackage), Option(batchRef))
           _ <- logWithFileRef("Started step function execution")
         } yield ()
       }

--- a/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/SeriesMapper.scala
+++ b/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/SeriesMapper.scala
@@ -6,23 +6,23 @@ import uk.gov.nationalarchives.ingestparsedcourtdocumenteventhandler.SeriesMappe
 import java.net.URI
 
 class SeriesMapper(validCourts: Set[Court]) {
-  def createDepartmentSeries(
+  def createDepartmentAndSeries(
       potentialCourt: Option[String],
       skipSeriesLookup: Boolean
-  ): IO[DepartmentSeries] = {
+  ): IO[DepartmentAndSeries] = {
     potentialCourt
       .map { court =>
         val potentiallyFoundCourt: Option[Court] = validCourts.find(_.code == court.toUpperCase)
         potentiallyFoundCourt match {
-          case None if skipSeriesLookup => IO.pure(DepartmentSeries(None, None))
+          case None if skipSeriesLookup => IO.pure(DepartmentAndSeries(None, None))
           case None                     => IO.raiseError(new Exception(s"Cannot find series and department for court $court"))
           case _ =>
             IO.pure(
-              DepartmentSeries(potentiallyFoundCourt.map(_.dept), potentiallyFoundCourt.map(_.series))
+              DepartmentAndSeries(potentiallyFoundCourt.map(_.dept), potentiallyFoundCourt.map(_.series))
             )
         }
       }
-      .getOrElse(IO.pure(DepartmentSeries(None, None)))
+      .getOrElse(IO.pure(DepartmentAndSeries(None, None)))
 
   }
 }
@@ -33,7 +33,7 @@ object SeriesMapper {
       metadataPackage: URI
   )
 
-  case class DepartmentSeries(potentialDepartment: Option[String], potentialSeries: Option[String])
+  case class DepartmentAndSeries(potentialDepartment: Option[String], potentialSeries: Option[String])
   case class Court(code: String, dept: String, series: String)
 
   def apply(): SeriesMapper = new SeriesMapper(seriesMap)

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
@@ -347,8 +347,6 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
     sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
     sfnRequest.name should equal("TEST-REFERENCE")
 
-    input.series.get should equal("TEST SERIES")
-    input.department.get should equal("TEST")
     input.batchId should equal("TEST-REFERENCE")
     input.metadataPackage.toString should equal("s3://outputBucket/TEST-REFERENCE/metadata.json")
   }
@@ -376,8 +374,6 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
       sfnRequest.stateMachineArn should equal("arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName")
       sfnRequest.name should equal("TEST-REFERENCE")
 
-      input.series should equal(expectedSeries)
-      input.department should equal(expectedDepartment)
       input.batchId should equal("TEST-REFERENCE")
       input.metadataPackage.toString should equal("s3://outputBucket/TEST-REFERENCE/metadata.json")
     }

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/SeriesMapperTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/SeriesMapperTest.scala
@@ -36,36 +36,36 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
   assert(courtToSeries.length == seriesMap.size)
 
   forAll(courtToSeries) { (court, series) =>
-    "createDepartmentSeries" should s"return $series for court $court" in {
+    "createDepartmentAndSeries" should s"return $series for court $court" in {
       val seriesMapper = SeriesMapper()
       val output =
-        seriesMapper.createDepartmentSeries(Option(court), skipSeriesLookup = false).unsafeRunSync()
+        seriesMapper.createDepartmentAndSeries(Option(court), skipSeriesLookup = false).unsafeRunSync()
       output.potentialDepartment.get should equal(series.split(' ').head)
       output.potentialSeries.get should equal(series)
     }
   }
 
-  "createDepartmentSeries" should "return an error if a court does not yield a series and 'skipSeriesLookup' is set to false" in {
+  "createDepartmentAndSeries" should "return an error if a court does not yield a series and 'skipSeriesLookup' is set to false" in {
     val seriesMapper = SeriesMapper()
     val ex = intercept[Exception] {
-      seriesMapper.createDepartmentSeries(Option("invalidCourt"), skipSeriesLookup = false).unsafeRunSync()
+      seriesMapper.createDepartmentAndSeries(Option("invalidCourt"), skipSeriesLookup = false).unsafeRunSync()
     }
     val expectedMessage = s"Cannot find series and department for court invalidCourt"
     ex.getMessage should equal(expectedMessage)
   }
 
-  "createDepartmentSeries" should "return an empty department and series if a court does not yield a series but 'skipSeriesLookup' is set to true" in {
+  "createDepartmentAndSeries" should "return an empty department and series if a court does not yield a series but 'skipSeriesLookup' is set to true" in {
     val seriesMapper = SeriesMapper()
     val output =
-      seriesMapper.createDepartmentSeries(Option("invalidCourt"), skipSeriesLookup = true).unsafeRunSync()
+      seriesMapper.createDepartmentAndSeries(Option("invalidCourt"), skipSeriesLookup = true).unsafeRunSync()
 
     output.potentialSeries should equal(None)
     output.potentialDepartment should equal(None)
   }
 
-  "createDepartmentSeries" should "return an empty department and series if the court is missing" in {
+  "createDepartmentAndSeries" should "return an empty department and series if the court is missing" in {
     val seriesMapper = SeriesMapper()
-    val output = seriesMapper.createDepartmentSeries(None, skipSeriesLookup = false).unsafeRunSync()
+    val output = seriesMapper.createDepartmentAndSeries(None, skipSeriesLookup = false).unsafeRunSync()
 
     output.potentialSeries should equal(None)
     output.potentialDepartment should equal(None)

--- a/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/SeriesMapperTest.scala
+++ b/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/SeriesMapperTest.scala
@@ -36,38 +36,38 @@ class SeriesMapperTest extends AnyFlatSpec with MockitoSugar with TableDrivenPro
   assert(courtToSeries.length == seriesMap.size)
 
   forAll(courtToSeries) { (court, series) =>
-    "createOutput" should s"return $series for court $court" in {
+    "createDepartmentSeries" should s"return $series for court $court" in {
       val seriesMapper = SeriesMapper()
       val output =
-        seriesMapper.createOutput(s3Uri, "batch", Option(court), skipSeriesLookup = false).unsafeRunSync()
-      output.department.get should equal(series.split(' ').head)
-      output.series.get should equal(series)
+        seriesMapper.createDepartmentSeries(Option(court), skipSeriesLookup = false).unsafeRunSync()
+      output.potentialDepartment.get should equal(series.split(' ').head)
+      output.potentialSeries.get should equal(series)
     }
   }
 
-  "createOutput" should "return an error if a court does not yield a series and 'skipSeriesLookup' is set to false" in {
+  "createDepartmentSeries" should "return an error if a court does not yield a series and 'skipSeriesLookup' is set to false" in {
     val seriesMapper = SeriesMapper()
     val ex = intercept[Exception] {
-      seriesMapper.createOutput(s3Uri, "batch", Option("invalidCourt"), skipSeriesLookup = false).unsafeRunSync()
+      seriesMapper.createDepartmentSeries(Option("invalidCourt"), skipSeriesLookup = false).unsafeRunSync()
     }
-    val expectedMessage = s"Cannot find series and department for court invalidCourt for batchId batch"
+    val expectedMessage = s"Cannot find series and department for court invalidCourt"
     ex.getMessage should equal(expectedMessage)
   }
 
-  "createOutput" should "return an empty department and series if a court does not yield a series but 'skipSeriesLookup' is set to true" in {
+  "createDepartmentSeries" should "return an empty department and series if a court does not yield a series but 'skipSeriesLookup' is set to true" in {
     val seriesMapper = SeriesMapper()
     val output =
-      seriesMapper.createOutput(s3Uri, "batch", Option("invalidCourt"), skipSeriesLookup = true).unsafeRunSync()
+      seriesMapper.createDepartmentSeries(Option("invalidCourt"), skipSeriesLookup = true).unsafeRunSync()
 
-    output.series should equal(None)
-    output.department should equal(None)
+    output.potentialSeries should equal(None)
+    output.potentialDepartment should equal(None)
   }
 
-  "createOutput" should "return an empty department and series if the court is missing" in {
+  "createDepartmentSeries" should "return an empty department and series if the court is missing" in {
     val seriesMapper = SeriesMapper()
-    val output = seriesMapper.createOutput(s3Uri, "batch", None, skipSeriesLookup = false).unsafeRunSync()
+    val output = seriesMapper.createDepartmentSeries(None, skipSeriesLookup = false).unsafeRunSync()
 
-    output.series should equal(None)
-    output.department should equal(None)
+    output.potentialSeries should equal(None)
+    output.potentialDepartment should equal(None)
   }
 }


### PR DESCRIPTION
This is not causing any problems as such but we’re sending
department and series into the step function input and we’re
not using it. It’s safest to take it out so we’re not tempted
to use it and to make sure it’s not being picked up somewhere unexpected.
