### PR TITLE
Minor lambda changes.

### DIFF
--- a/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
@@ -171,28 +171,6 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
       ),
       fileAOne,
       s"Expected 1 parent asset, found 2 assets for file ${assetA.id}"
-    ),
-    (
-      "Incorrect number of children for ingest_CC update",
-      List(
-        folderA,
-        assetA,
-        fileAOne
-      ),
-      assetA.copy(ingestedPreservica = true, ingestedCustodialCopy = true),
-      s"Asset id ${assetA.id}: has 2 children in the files table but found 1 children in the Preservation system"
-    ),
-    (
-      "Incorrect number of children for skipIngest update",
-      List(
-        folderA,
-        assetA,
-        fileAOne,
-        fileAOne,
-        fileATwo
-      ),
-      assetA.copy(ingestedPreservica = true, skipIngest = true),
-      s"Asset id ${assetA.id}: has 2 children in the files table but found 3 children in the Preservation system"
     )
   )
 

--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/resources/application.conf
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/resources/application.conf
@@ -1,3 +1,0 @@
-output-bucket = outputBucket
-sfn-arn = "arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName"
-dynamo-lock-table-name = "test-table"

--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
@@ -38,7 +38,7 @@ class LambdaTest extends AnyFlatSpec with BeforeAndAfterEach with TableDrivenPro
   case class DDBItem(ioId: DDBValue, batchId: DDBValue, message: DDBValue)
   case class DDBValue(S: String)
 
-  val config: Config = Config("", "", "")
+  val config: Config = Config("outputBucket", "arn:aws:states:eu-west-2:123456789:stateMachine:StateMachineName", "test-table")
 
   val reference = "TEST-REFERENCE"
   val uuidsAndChecksum: List[(String, String)] = List(


### PR DESCRIPTION
The parsed court document handler was loading its own config rather than
using the config passed to it. I've updated this.

The files change handler is throwing an error if there is an unexpected
number of children. We talked about this a little while ago and this can
be valid. At any rate, these errors are making it difficult to see if
the process is working so I've taken them out.
I've also added a couple of logging lines, I'll remove them later.
