### PR TITLE
Fix concurrency issues.

### DIFF
--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
@@ -77,8 +77,8 @@ object Aggregator:
     }
 
     private def startNewGroup(sourceId: String, config: Config, groupExpiryTime: Milliseconds)(using
-                                                                                               sfnClient: DASFNClient[F],
-                                                                                               enc: Encoder[SFNArguments]
+        sfnClient: DASFNClient[F],
+        enc: Encoder[SFNArguments]
     ): F[Group] = {
       val waitFor: Seconds = Math.ceil((groupExpiryTime - Generators().generateInstant.toEpochMilli.milliSeconds).toDouble / 1000).toInt.seconds
       val groupId: GroupId = GroupId(config.sourceSystem)
@@ -89,7 +89,7 @@ object Aggregator:
     }
 
     private def getNewOrExistingGroupId(atomicCell: AtomicCell[F, Map[String, Group]], config: Config, sourceId: String, lambdaTimeoutTime: Milliseconds)(using
-                                                                                                                                                          Encoder[SFNArguments]
+        Encoder[SFNArguments]
     ): F[GroupId] = {
       def log = logWithReason(sourceId)
       val groupExpiryTime: Milliseconds = lambdaTimeoutTime + config.maxSecondaryBatchingWindow.toMilliSeconds

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
@@ -76,9 +76,9 @@ object Aggregator:
       )
     }
 
-    private def startNewGroup(sourceId: String, config: Config, groupExpiryTime: MilliSeconds)(using
-        sfnClient: DASFNClient[F],
-        enc: Encoder[SFNArguments]
+    private def startNewGroup(sourceId: String, config: Config, groupExpiryTime: Milliseconds)(using
+                                                                                               sfnClient: DASFNClient[F],
+                                                                                               enc: Encoder[SFNArguments]
     ): F[Group] = {
       val waitFor: Seconds = Math.ceil((groupExpiryTime - Generators().generateInstant.toEpochMilli.milliSeconds).toDouble / 1000).toInt.seconds
       val groupId: GroupId = GroupId(config.sourceSystem)
@@ -88,11 +88,11 @@ object Aggregator:
       }
     }
 
-    private def getNewOrExistingGroupId(atomicCell: AtomicCell[F, Map[String, Group]], config: Config, sourceId: String, lambdaTimeoutTime: MilliSeconds)(using
-        Encoder[SFNArguments]
+    private def getNewOrExistingGroupId(atomicCell: AtomicCell[F, Map[String, Group]], config: Config, sourceId: String, lambdaTimeoutTime: Milliseconds)(using
+                                                                                                                                                          Encoder[SFNArguments]
     ): F[GroupId] = {
       def log = logWithReason(sourceId)
-      val groupExpiryTime: MilliSeconds = lambdaTimeoutTime + config.maxSecondaryBatchingWindow.toMilliSeconds
+      val groupExpiryTime: Milliseconds = lambdaTimeoutTime + config.maxSecondaryBatchingWindow.toMilliSeconds
       atomicCell
         .evalUpdateAndGet { groupCache =>
           val groupF = groupCache.get(sourceId) match

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Duration.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Duration.scala
@@ -5,27 +5,27 @@ import io.circe.Json
 object Duration:
   opaque type Seconds = Int
 
-  opaque type MilliSeconds = Long
+  opaque type Milliseconds = Long
 
   object Seconds:
     def apply(length: Int): Seconds = length
 
   object MilliSeconds:
-    def apply(length: Long): MilliSeconds = length
+    def apply(length: Long): Milliseconds = length
 
   extension (s: Seconds)
     def *(other: Int): Int = s * other
     def length: Int = s
     def toJson: Json = Json.fromInt(s)
-    def toMilliSeconds: MilliSeconds = s * 1000
+    def toMilliSeconds: Milliseconds = s * 1000
 
-  extension (m: MilliSeconds)
+  extension (m: Milliseconds)
     def length: Long = m
-    def +(other: MilliSeconds): MilliSeconds = m + other
-    def -(other: MilliSeconds): Long = m - other
+    def +(other: Milliseconds): Milliseconds = m + other
+    def -(other: Milliseconds): Long = m - other
 
   extension (i: Int) def seconds: Seconds = Seconds(i)
 
-  extension (l: Long) def milliSeconds: MilliSeconds = MilliSeconds(l)
+  extension (l: Long) def milliSeconds: Milliseconds = MilliSeconds(l)
 
 end Duration

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Duration.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Duration.scala
@@ -21,4 +21,9 @@ object Duration:
   extension (m: MilliSeconds)
     def length: Long = m
     def +(other: Long): Long = m + other
+
+  extension (i: Int) def seconds: Seconds = Seconds(i)
+
+  extension (l: Long) def milliSeconds: MilliSeconds = MilliSeconds(l)
+
 end Duration

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Duration.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Duration.scala
@@ -17,10 +17,12 @@ object Duration:
     def *(other: Int): Int = s * other
     def length: Int = s
     def toJson: Json = Json.fromInt(s)
+    def toMilliSeconds: MilliSeconds = s * 1000
 
   extension (m: MilliSeconds)
     def length: Long = m
-    def +(other: Long): Long = m + other
+    def +(other: MilliSeconds): MilliSeconds = m + other
+    def -(other: MilliSeconds): Long = m - other
 
   extension (i: Int) def seconds: Seconds = Seconds(i)
 


### PR DESCRIPTION
The problem we're having is that each fiber was running in parallel and
trying to get the Group from the Map at the same time. Ref allows
parallel access to the Map. All the fibers were finding the Map empty
and starting a new group.

The solution is to use AtomicCell which only allows one thread to access
it at once. To make this work, I've refactored it so the read and write
of the map are inside the same evalMap call on AtomicCell.
