### PR TITLE
Encode MessageType correctly.

### DIFF
--- a/scala/lambdas/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
@@ -184,7 +184,7 @@ object Lambda:
       case IngestComplete => "preserve.digital.asset.ingest.complete"
     case IngestUpdate, IngestComplete
 
-  given Encoder[MessageType] = deriveEncoder[MessageType]
+  given Encoder[MessageType] = (messageType: MessageType) => Json.fromString(messageType.toString)
   given Encoder[OutputProperties] = deriveEncoder[OutputProperties]
   given Encoder[OutputParameters] = deriveEncoder[OutputParameters]
   given Encoder[OutputMessage] = deriveEncoder[OutputMessage]


### PR DESCRIPTION
This is being printed as
```json
"type": {
 "IngestUpdate": {}
 }
```
This is unhelpful, it should be
```json
"type": "preserve.digital.asset.ingest.update"
```

This should fix it
