### PR TITLE
DR2-1884 Change handler not sending update message

### DIFF
--- a/scala/lambdas/ingest-files-change-handler/TestCases.md
+++ b/scala/lambdas/ingest-files-change-handler/TestCases.md
@@ -401,6 +401,20 @@ Custodial Copy, where all the child Files are downloaded to Custodial Copy.
 }
 ```
 
+```json
+{
+  "properties": {
+    "messageId": "e2f8a9a9-4935-4f4f-96f8-7bdfa75960e3",
+    "parentMessageId": null,
+    "timestamp": "2024-05-23T10:13:16.925Z",
+    "type": "preserve.digital.asset.ingest.update"
+  },
+  "parameters": {
+    "assetId": "1"
+  }
+}
+```
+
 ## 6. `ingested_PS`+`ingested_CC` for 1 Asset only where all files are not complete
 
 This test models the action of adding `ingested_PS` or `ingested_CC` to the Asset after reconciling/downloading to
@@ -467,8 +481,19 @@ Custodial Copy, where **not** all the child Files are downloaded to Custodial Co
 
 ### Output (messages sent)
 
-No output.
-
+```json
+{
+  "properties": {
+    "messageId": "e2f8a9a9-4935-4f4f-96f8-7bdfa75960e3",
+    "parentMessageId": null,
+    "timestamp": "2024-05-23T10:13:16.925Z",
+    "type": "preserve.digital.asset.ingest.update"
+  },
+  "parameters": {
+    "assetId": "1"
+  }
+}
+```
 ## 7. `ingested_CC` for 1 File only where not all files are complete
 
 This test models the action of adding `ingested_CC` to a File after downloading to Custodial Copy, where the Asset is
@@ -532,7 +557,19 @@ but **not** all the Files are downloaded to Custodial Copy.
 
 ### Output (messages sent)
 
-No output.
+```json
+{
+  "properties": {
+    "messageId": "e2f8a9a9-4935-4f4f-96f8-7bdfa75960e3",
+    "parentMessageId": null,
+    "timestamp": "2024-05-23T10:13:16.925Z",
+    "type": "preserve.digital.asset.ingest.update"
+  },
+  "parameters": {
+    "assetId": "3"
+  }
+}
+```
 
 ## 8. `ingested_CC` for 1 File only where all files are complete
 
@@ -604,6 +641,20 @@ all the Files are downloaded to Custodial Copy.
     "parentMessageId": null,
     "timestamp": "2024-05-23T10:13:16.925Z",
     "type": "preserve.digital.asset.ingest.complete"
+  },
+  "parameters": {
+    "assetId": "1"
+  }
+}
+```
+
+```json
+{
+  "properties": {
+    "messageId": "e2f8a9a9-4935-4f4f-96f8-7bdfa75960e3",
+    "parentMessageId": null,
+    "timestamp": "2024-05-23T10:13:16.925Z",
+    "type": "preserve.digital.asset.ingest.update"
   },
   "parameters": {
     "assetId": "1"
@@ -715,6 +766,21 @@ passthrough, hence 2 messages.
 }
 ```
 
+```JSON
+{
+  "properties": {
+    "messageId": "e2f8a9a9-4935-4f4f-96f8-7bdfa75960e3",
+    "parentMessageId": null,
+    "timestamp": "2024-05-23T10:13:16.925Z",
+    "type": "preserve.digital.asset.ingest.update"
+  },
+  "parameters": {
+    "assetId": "1"
+  }
+}
+```
+
+
 ## 10. `ingested_CC` for a File where all files are complete, and the asset has been in multiple ingest batches
 
 This test models the action of adding `ingested_CC` to a File after downloading to Custodial Copy, where all the child
@@ -805,6 +871,19 @@ after the IO has already been processed by the CC application.
     "parentMessageId": null,
     "timestamp": "2024-05-23T10:13:16.925Z",
     "type": "preserve.digital.asset.ingest.complete"
+  },
+  "parameters": {
+    "assetId": "1"
+  }
+}
+```
+```JSON
+{
+  "properties": {
+    "messageId": "e2f8a9a9-4935-4f4f-96f8-7bdfa75960e3",
+    "parentMessageId": null,
+    "timestamp": "2024-05-23T10:13:16.925Z",
+    "type": "preserve.digital.asset.ingest.update"
   },
   "parameters": {
     "assetId": "1"

--- a/scala/lambdas/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
@@ -67,7 +67,6 @@ class Lambda extends LambdaRunner[DynamodbEvent, Unit, Config, Dependencies]:
       parentAssets <- dependencies.daDynamoDbClient.getItems[AssetDynamoTable, FilesTablePrimaryKey](List(parentPrimaryKey), config.dynamoTableName)
     } yield parentAssets.head
 
-
     def processIngestedPreservica(asset: AssetDynamoTable) =
       if asset.ingestedPreservica && !asset.skipIngest then sendOutputMessage(asset, IngestUpdate)
       else if asset.ingestedPreservica && asset.skipIngest then
@@ -84,7 +83,6 @@ class Lambda extends LambdaRunner[DynamodbEvent, Unit, Config, Dependencies]:
           }
         } yield ()
       else IO.unit
-
 
     def processIngestedPreservicaCC(asset: AssetDynamoTable) =
       if asset.ingestedPreservica && asset.ingestedCustodialCopy then

--- a/scala/lambdas/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/main/scala/uk/gov/nationalarchives/ingestfileschangehandler/Lambda.scala
@@ -65,6 +65,7 @@ class Lambda extends LambdaRunner[DynamodbEvent, Unit, Config, Dependencies]:
       }(new Exception(s"Cannot find a direct parent for file ${fileRow.id}"))
       parentPrimaryKey <- IO.pure(FilesTablePrimaryKey(FilesTablePartitionKey(parentId), FilesTableSortKey(fileRow.batchId)))
       parentAssets <- dependencies.daDynamoDbClient.getItems[AssetDynamoTable, FilesTablePrimaryKey](List(parentPrimaryKey), config.dynamoTableName)
+      _ <- IO.raiseWhen(parentAssets.length != 1)(new Exception(s"Expected 1 parent asset, found ${parentAssets.length} assets for file $parentId"))
     } yield parentAssets.head
 
     def processIngestedPreservica(asset: AssetDynamoTable) =

--- a/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
@@ -83,7 +83,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
       List(outputBuilder(assetB, IngestUpdate))
     ),
     (
-      "ingested_PS and ingested_CC for 1 Asset only where all files are complete, sends complete message",
+      "ingested_PS and ingested_CC for 1 Asset only where all files are complete, sends complete and update message",
       List(
         folderA,
         assetA.copy(ingestedPreservica = true, ingestedCustodialCopy = true),
@@ -91,10 +91,10 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
         fileATwo.copy(ingestedCustodialCopy = true)
       ),
       assetA.copy(ingestedPreservica = true, ingestedCustodialCopy = true),
-      List(outputBuilder(assetA, IngestComplete))
+      List(outputBuilder(assetA, IngestUpdate), outputBuilder(assetA, IngestComplete))
     ),
     (
-      "ingested_PS and ingested_CC for 1 Asset only where all files are not complete, sends no message",
+      "ingested_PS and ingested_CC for 1 Asset only where all files are not complete, sends an ingest update message",
       List(
         folderA,
         assetA.copy(ingestedPreservica = true, ingestedCustodialCopy = true),
@@ -102,7 +102,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
         fileATwo.copy(ingestedCustodialCopy = true)
       ),
       assetA.copy(ingestedPreservica = true, ingestedCustodialCopy = true),
-      Nil
+      List(outputBuilder(assetA, IngestUpdate))
     ),
     (
       "ingested_CC for 1 File only where not all files are complete, sends no message",
@@ -113,7 +113,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
         fileATwo.copy(ingestedCustodialCopy = true)
       ),
       fileATwo.copy(ingestedCustodialCopy = true),
-      Nil
+      List(outputBuilder(assetA, IngestUpdate))
     ),
     (
       "ingested_CC for 1 File only where all files are complete, sends complete message",
@@ -124,7 +124,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
         fileATwo.copy(ingestedCustodialCopy = true)
       ),
       fileATwo.copy(ingestedCustodialCopy = true),
-      List(outputBuilder(assetA, IngestComplete))
+      List(outputBuilder(assetA, IngestUpdate), outputBuilder(assetA, IngestComplete))
     ),
     (
       "ingested_PS and ingested_CC for an Asset where all files are complete, and the asset has been in multiple ingest batches, sends two complete messages",
@@ -139,7 +139,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
         fileBTwo
       ),
       assetA.copy(ingestedPreservica = true, ingestedCustodialCopy = true),
-      List(outputBuilder(assetA, IngestComplete), outputBuilder(assetB, IngestComplete))
+      List(outputBuilder(assetA, IngestUpdate), outputBuilder(assetA, IngestComplete), outputBuilder(assetB, IngestComplete))
     ),
     (
       "ingested_CC for a File where all files are complete, and the asset has been in multiple ingest batches, sends two complete messages",
@@ -154,7 +154,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
         fileBTwo
       ),
       fileAOne.copy(ingestedCustodialCopy = true),
-      List(outputBuilder(assetA, IngestComplete), outputBuilder(assetB, IngestComplete))
+      List(outputBuilder(assetA, IngestUpdate), outputBuilder(assetA, IngestComplete), outputBuilder(assetB, IngestComplete))
     )
   )
 


### PR DESCRIPTION
The problem is with the logic in the change handler and the order we get sent the messages.

Because the custodial-copy process picks up the ingested files before the step function sets ingested_PS to true, we get two updates in this order

```
ingested_PS=false, ingested_CC=true
ingested_PS=true,ingested_CC= true`
```

The logic was:

```scala
if asset.ingestedPreservica && asset.ingestedCustodialCopy then
  //send IngestComplete
else if asset.ingestedPreservica && asset.skipIngest then
  //Send IngestUpdate with some other logic around assets with the same Id
else if asset.ingestedPreservica then
 // Send ingest update message
So it was never hitting the last else if because ingestedPreservica was never true on its own.
```

The solution is to split them:

```scala
if asset.ingestedPreservica then
  //send IngestComplete
else if asset.ingestedPreservica && asset.skipIngest then
  //Send IngestUpdate with some other logic around assets with the same Id

if asset.ingestedPreservica && asset.ingestedCustodialCopy then
 // Send ingest update message
```

This means that we’ll get an IngestUpdate message and an IngestComplete message.

If we do sometimes get

```
ingested_PS=true, ingested_CC=false
ingested_PS=true,ingested_CC= true
```

Then we’ll get two IngestUpdate messages and one IngestComplete message. We can live with this, both because it’s unlikely and because anything downstream should be idempotent. It’s the IngestComplete message that other teams will react to and we’ll only get one of those.
