### PR TITLE
DR2-1876 missing parent errors.

### DIFF
--- a/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
@@ -161,16 +161,12 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
   val errorsTable: TableFor4[String, List[DynamoRow], DynamoRow, String] = Table(
     ("title", "rowsInTable", "newRowInput", "expectedErrorMessage"),
     (
-      "Multiple assets found for file parent",
+      "Parent path missing from file",
       List(
-        folderA,
-        assetA,
-        assetA,
-        fileAOne,
-        fileATwo
+        folderA
       ),
-      fileAOne,
-      s"Expected 1 parent asset, found 2 assets for file ${assetA.id}"
+      fileAOne.copy(parentPath = None),
+      s"Cannot find a direct parent for file ${fileAOne.id}"
     )
   )
 


### PR DESCRIPTION
We have been getting an error:

`Expected 1 parent asset, found 0 assets for file <id>: java.lang.Exception`

This is most likely because the update to the asset has been processed first and the asset has been deleted.

The solution is just to ignore it if the file has no parent.

This is because if the file has no parent, this means that the parent has already been processed and the ingest complete message sent.

We can’t ever get into a race condition if the asset is complete and the files aren’t because the ingest complete message won’t send for the asset if that’s true and the asset will still be there.

I’ve changed the method which gets the parent asset to return an `Option`. If there isn’t one, it will do nothing.

I've removed the test which checks for this error and I've added one in for a missing parent path which should never happen.
