### PR TITLE
DR2-1909 Ingest failure notifications

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,3 +1,4 @@
+import Dependencies.*
 ThisBuild / scalaVersion := "3.5.1"
 
 lazy val root = (project in file("."))
@@ -8,3 +9,16 @@ lazy val root = (project in file("."))
   )
 
 lazy val ingestLambdasRoot = project in file("./scala/lambdas")
+
+lazy val e2eTests = (project in file("./scala/e2e-tests"))
+  .settings(
+    publish / skip := true,
+    libraryDependencies ++= Seq(
+      pureConfig % Test,
+      fs2Core % Test,
+      s3Client % Test,
+      sqsClient % Test,
+      scalaTest % Test,
+    ),
+  )
+

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,3 @@
-import Dependencies.*
 ThisBuild / scalaVersion := "3.5.1"
 
 lazy val root = (project in file("."))
@@ -9,16 +8,3 @@ lazy val root = (project in file("."))
   )
 
 lazy val ingestLambdasRoot = project in file("./scala/lambdas")
-
-lazy val e2eTests = (project in file("./scala/e2e-tests"))
-  .settings(
-    publish / skip := true,
-    libraryDependencies ++= Seq(
-      pureConfig % Test,
-      fs2Core % Test,
-      s3Client % Test,
-      sqsClient % Test,
-      scalaTest % Test,
-    ),
-  )
-

--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -12,6 +12,7 @@ lazy val ingestLambdasRoot = (project in file("."))
     getLatestPreservicaVersion,
     ingestAssetOpexCreator,
     ingestAssetReconciler,
+    ingestFailureNotifications,
     ingestFilesChangeHandler,
     ingestFindExistingAsset,
     ingestFolderOpexCreator,
@@ -289,6 +290,16 @@ lazy val custodialCopyQueueCreator = (project in file("custodial-copy-queue-crea
     libraryDependencies ++= Seq(
       preservicaClient,
       sqsClient
+    )
+  )
+
+lazy val ingestFailureNotifications = (project in file("ingest-failure-notifications"))
+  .settings(commonSettings)
+  .dependsOn(utils, dynamoFormatters)
+  .settings(
+    libraryDependencies ++= Seq(
+      snsClient,
+      dynamoClient
     )
   )
 

--- a/scala/lambdas/custodial-copy-queue-creator/src/main/scala/uk/gov/nationalarchives/custodialcopyqueuecreator/Lambda.scala
+++ b/scala/lambdas/custodial-copy-queue-creator/src/main/scala/uk/gov/nationalarchives/custodialcopyqueuecreator/Lambda.scala
@@ -13,7 +13,7 @@ import uk.gov.nationalarchives.custodialcopyqueuecreator.Lambda.*
 import uk.gov.nationalarchives.custodialcopyqueuecreator.Lambda.MessageBody.*
 import uk.gov.nationalarchives.utils.LambdaRunner
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
-import uk.gov.nationalarchives.utils.EventDecoders.given
+import uk.gov.nationalarchives.utils.EventCodecs.given
 import io.circe.parser.decode
 import uk.gov.nationalarchives.DASQSClient.FifoQueueConfiguration
 import uk.gov.nationalarchives.dp.client.EntityClient.EntityType

--- a/scala/lambdas/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/entityeventgenerator/Lambda.scala
+++ b/scala/lambdas/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/entityeventgenerator/Lambda.scala
@@ -10,7 +10,7 @@ import software.amazon.awssdk.services.dynamodb.model.*
 import sttp.capabilities.fs2.Fs2Streams
 import uk.gov.nationalarchives.DADynamoDBClient.DADynamoDbRequest
 import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient}
-import uk.gov.nationalarchives.utils.EventDecoders.given
+import uk.gov.nationalarchives.utils.EventCodecs.given
 import uk.gov.nationalarchives.utils.LambdaRunner
 import uk.gov.nationalarchives.entityeventgenerator.Lambda.*
 import uk.gov.nationalarchives.dp.client.Entities.Entity

--- a/scala/lambdas/get-latest-preservica-version-lambda/src/main/scala/uk/gov/nationalarchives/getlatestpreservicaversion/Lambda.scala
+++ b/scala/lambdas/get-latest-preservica-version-lambda/src/main/scala/uk/gov/nationalarchives/getlatestpreservicaversion/Lambda.scala
@@ -7,7 +7,7 @@ import org.scanamo.generic.auto.*
 import pureconfig.ConfigReader
 import pureconfig.generic.derivation.default.*
 import sttp.capabilities.fs2.Fs2Streams
-import uk.gov.nationalarchives.utils.EventDecoders.given
+import uk.gov.nationalarchives.utils.EventCodecs.given
 import uk.gov.nationalarchives.dp.client.EntityClient
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
 import uk.gov.nationalarchives.getlatestpreservicaversion.Lambda.*

--- a/scala/lambdas/ingest-failure-notifications/README.md
+++ b/scala/lambdas/ingest-failure-notifications/README.md
@@ -1,0 +1,29 @@
+# DR2 Ingest failure notifications
+
+## Lambda input
+
+The lambda takes the following input from an EventBridge event:
+
+```json
+{
+  "detail": {
+    "input": "{\"groupId\":\"TDR_c0ce1c2e-03fc-4cef-bc22-f95547ad3448\",\"batchId\":\"TDR_c0ce1c2e-03fc-4cef-bc22-f95547ad3448_0\"}"
+  }
+}
+
+```
+
+## Lambda output
+
+There is no output
+
+[Link to the infrastructure code](https://github.com/nationalarchives/dr2-terraform-environments)
+
+## Environment Variables
+
+| Name                        | Description                                |
+|-----------------------------|--------------------------------------------|
+| DDB_LOCK_TABLE              | The name of the Dynamo lock table          |
+| LOCK_DDB_TABLE_GROUP_ID_IDX | The name of the lock table secondary index |
+| TOPIC_ARN                   | The arn of the notifications topic         |
+

--- a/scala/lambdas/ingest-failure-notifications/src/main/resources/application.conf
+++ b/scala/lambdas/ingest-failure-notifications/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+lock-table-name=${DDB_LOCK_TABLE}
+lock-table-gsi-name=${LOCK_DDB_TABLE_GROUP_ID_IDX}
+topic-arn = ${TOPIC_ARN}

--- a/scala/lambdas/ingest-failure-notifications/src/main/scala/uk/gov/nationalarchives/ingestfailurenotifications/Lambda.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/main/scala/uk/gov/nationalarchives/ingestfailurenotifications/Lambda.scala
@@ -1,0 +1,64 @@
+package uk.gov.nationalarchives.ingestfailurenotifications
+
+import cats.effect.IO
+import io.circe.DecodingFailure.Reason.CustomReason
+import io.circe.generic.semiauto.deriveDecoder
+import io.circe.{Decoder, DecodingFailure, HCursor}
+import io.circe.parser.decode
+import pureconfig.ConfigReader
+import pureconfig.generic.derivation.default.*
+import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient}
+import uk.gov.nationalarchives.utils.LambdaRunner
+import uk.gov.nationalarchives.ingestfailurenotifications.Lambda.{*, given}
+import uk.gov.nationalarchives.DADynamoDBClient.given
+import org.scanamo.syntax.*
+import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.IngestLockTableItem
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageStatus.IngestError
+import uk.gov.nationalarchives.utils.EventCodecs.given
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageType.IngestUpdate
+import uk.gov.nationalarchives.utils.ExternalUtils.{OutputMessage, OutputParameters, OutputProperties}
+
+import java.time.Instant
+import java.util.UUID
+
+class Lambda extends LambdaRunner[SfnEvent, Unit, Config, Dependencies]:
+  override def handler: (SfnEvent, Config, Dependencies) => IO[Unit] = (event, config, dependencies) =>
+    for {
+      items <- dependencies.dynamoClient
+        .queryItems[IngestLockTableItem](config.lockTableName, "groupId" === event.detail.input.groupId, Option(config.lockTableGsiName))
+      messages = items.map { item =>
+        OutputMessage(
+          OutputProperties(event.detail.input.batchId, dependencies.uuidGenerator(), None, Instant.now, IngestUpdate),
+          OutputParameters(item.assetId, IngestError)
+        )
+      }
+      _ <- dependencies.snsClient.publish(config.topicArn)(messages)
+    } yield ()
+
+  override def dependencies(config: Config): IO[Dependencies] =
+    IO.pure(Dependencies(DASNSClient[IO](), DADynamoDBClient[IO](), () => UUID.randomUUID))
+end Lambda
+
+object Lambda:
+  given Decoder[SfnInput] = deriveDecoder[SfnInput]
+
+  given Decoder[SfnDetail] = (c: HCursor) =>
+    for {
+      inputString <- c.downField("input").as[String]
+      input <- decode[SfnInput](inputString).left.map(err => DecodingFailure(CustomReason(err.getMessage), c))
+    } yield SfnDetail(input)
+
+  given Decoder[SfnEvent] = (c: HCursor) =>
+    for {
+      detail <- c.downField("detail").as[SfnDetail]
+    } yield SfnEvent(detail)
+
+  case class SfnInput(groupId: String, batchId: String)
+
+  case class SfnDetail(input: SfnInput)
+
+  case class SfnEvent(detail: SfnDetail)
+
+  case class Config(topicArn: String, lockTableName: String, lockTableGsiName: String) derives ConfigReader
+
+  case class Dependencies(snsClient: DASNSClient[IO], dynamoClient: DADynamoDBClient[IO], uuidGenerator: () => UUID)

--- a/scala/lambdas/ingest-failure-notifications/src/main/scala/uk/gov/nationalarchives/ingestfailurenotifications/Lambda.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/main/scala/uk/gov/nationalarchives/ingestfailurenotifications/Lambda.scala
@@ -12,7 +12,7 @@ import uk.gov.nationalarchives.utils.LambdaRunner
 import uk.gov.nationalarchives.ingestfailurenotifications.Lambda.{*, given}
 import uk.gov.nationalarchives.DADynamoDBClient.given
 import org.scanamo.syntax.*
-import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.IngestLockTableItem
+import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{IngestLockTableItem, groupId}
 import uk.gov.nationalarchives.utils.ExternalUtils.MessageStatus.IngestError
 import uk.gov.nationalarchives.utils.EventCodecs.given
 import uk.gov.nationalarchives.utils.ExternalUtils.MessageType.IngestUpdate
@@ -25,7 +25,7 @@ class Lambda extends LambdaRunner[SfnEvent, Unit, Config, Dependencies]:
   override def handler: (SfnEvent, Config, Dependencies) => IO[Unit] = (event, config, dependencies) =>
     for {
       items <- dependencies.dynamoClient
-        .queryItems[IngestLockTableItem](config.lockTableName, "groupId" === event.detail.input.groupId, Option(config.lockTableGsiName))
+        .queryItems[IngestLockTableItem](config.lockTableName, groupId === event.detail.input.groupId, Option(config.lockTableGsiName))
       messages = items.map { item =>
         OutputMessage(
           OutputProperties(event.detail.input.batchId, dependencies.uuidGenerator(), None, Instant.now, IngestUpdate),

--- a/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTest.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTest.scala
@@ -1,0 +1,65 @@
+package uk.gov.nationalarchives.ingestfailurenotifications
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.*
+import uk.gov.nationalarchives.ingestfailurenotifications.Lambda.*
+import uk.gov.nationalarchives.ingestfailurenotifications.LambdaTestUtils.*
+import uk.gov.nationalarchives.utils.ExternalUtils.{MessageStatus, MessageType, OutputMessage}
+
+import scala.annotation.tailrec
+
+class LambdaTest extends AnyFlatSpec:
+
+  "handler" should "send one message for each item in the lock table" in {
+    val items = generateItems()
+    val snsMessages = runLambda(items, SfnInput("groupId", "groupId_0"))
+
+    snsMessages.size should equal(items.size)
+
+    checkMessages(snsMessages)
+
+    @tailrec
+    def checkMessages(snsMessages: List[OutputMessage]): Unit = {
+      if snsMessages.isEmpty then ()
+      else
+        val parameters = snsMessages.head.parameters
+        val properties = snsMessages.head.properties
+        val itemIdx = items.length - snsMessages.length
+
+        parameters.assetId should equal(items(itemIdx).assetId)
+        parameters.status should equal(MessageStatus.IngestError)
+
+        properties.`type` should equal(MessageType.IngestUpdate)
+        properties.messageId should equal(uuids.head)
+        properties.executionId should equal("groupId_0")
+        properties.parentMessageId should equal(None)
+        checkMessages(snsMessages.tail)
+    }
+  }
+
+  "handler" should "send no messages if there are items in the lock table with a different group id" in {
+    val items = generateItems()
+    val snsMessages = runLambda(items, SfnInput("differentGroupId", "groupId_0"))
+
+    snsMessages.size should equal(0)
+  }
+
+  "handler" should "send no messages if there are no items in the lock table" in {
+    val snsMessages = runLambda(Nil, SfnInput("differentGroupId", "groupId_0"))
+
+    snsMessages.size should equal(0)
+  }
+
+  "handler" should "return an error if there is an error fetching from dynamo" in {
+    val ex = intercept[Exception] {
+      runLambda(Nil, SfnInput("groupId", "groupId_0"), dynamoError = true)
+    }
+    ex.getMessage should equal("Error getting dynamo items")
+  }
+
+  "handler" should "return an error if there is an error sending to sns" in {
+    val ex = intercept[Exception] {
+      runLambda(Nil, SfnInput("groupId", "groupId_0"), snsError = true)
+    }
+    ex.getMessage should equal("Error sending to SNS")
+  }

--- a/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTest.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTest.scala
@@ -6,8 +6,6 @@ import uk.gov.nationalarchives.ingestfailurenotifications.Lambda.*
 import uk.gov.nationalarchives.ingestfailurenotifications.LambdaTestUtils.*
 import uk.gov.nationalarchives.utils.ExternalUtils.{MessageStatus, MessageType, OutputMessage}
 
-import scala.annotation.tailrec
-
 class LambdaTest extends AnyFlatSpec:
 
   "handler" should "send one message for each item in the lock table" in {

--- a/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTest.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTest.scala
@@ -16,24 +16,16 @@ class LambdaTest extends AnyFlatSpec:
 
     snsMessages.size should equal(items.size)
 
-    checkMessages(snsMessages)
+    snsMessages.zipWithIndex.foreach { (message, idx) =>
+      val parameters = message.parameters
+      val properties = message.properties
 
-    @tailrec
-    def checkMessages(snsMessages: List[OutputMessage]): Unit = {
-      if snsMessages.isEmpty then ()
-      else
-        val parameters = snsMessages.head.parameters
-        val properties = snsMessages.head.properties
-        val itemIdx = items.length - snsMessages.length
-
-        parameters.assetId should equal(items(itemIdx).assetId)
-        parameters.status should equal(MessageStatus.IngestError)
-
-        properties.messageType should equal(MessageType.IngestUpdate)
-        properties.messageId should equal(uuids.head)
-        properties.executionId should equal("groupId_0")
-        properties.parentMessageId should equal(None)
-        checkMessages(snsMessages.tail)
+      parameters.assetId should equal(items(idx).assetId)
+      parameters.status should equal(MessageStatus.IngestError)
+      properties.messageType should equal(MessageType.IngestUpdate)
+      properties.messageId should equal(uuids.head)
+      properties.executionId should equal("groupId_0")
+      properties.parentMessageId should equal(None)
     }
   }
 

--- a/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTestUtils.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTestUtils.scala
@@ -1,0 +1,81 @@
+package uk.gov.nationalarchives.ingestfailurenotifications
+
+import cats.effect.{IO, Ref}
+import cats.effect.unsafe.implicits.global
+import io.circe.Encoder
+import org.scanamo.DynamoFormat
+import org.scanamo.request.RequestCondition
+import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
+import software.amazon.awssdk.services.sns.model.PublishBatchResponse
+import uk.gov.nationalarchives.{DADynamoDBClient, DASNSClient}
+import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.IngestLockTableItem
+import uk.gov.nationalarchives.ingestfailurenotifications.Lambda.{Config, Dependencies, SfnDetail, SfnEvent, SfnInput}
+import uk.gov.nationalarchives.utils.ExternalUtils.OutputMessage
+
+import java.util.UUID
+
+object LambdaTestUtils:
+
+  val uuids: List[UUID] = List(UUID.randomUUID)
+
+  val config: Config = Config("topicArn", "lockTableName", "lockTableGsiName")
+
+  def createDependencies(
+      dynamoItemsRef: Ref[IO, List[IngestLockTableItem]],
+      snsMessagesRef: Ref[IO, List[OutputMessage]],
+      dynamoError: Boolean,
+      snsError: Boolean
+  ): Dependencies = {
+    val dynamoClient = new DADynamoDBClient[IO] {
+      override def deleteItems[T](tableName: String, primaryKeyAttributes: List[T])(using DynamoFormat[T]): IO[List[BatchWriteItemResponse]] = IO.pure(Nil)
+
+      override def writeItem(dynamoDbWriteRequest: DADynamoDBClient.DADynamoDbWriteItemRequest): IO[Int] = IO.pure(1)
+
+      override def writeItems[T](tableName: String, items: List[T])(using format: DynamoFormat[T]): IO[List[BatchWriteItemResponse]] = IO.pure(Nil)
+
+      override def queryItems[U](tableName: String, requestCondition: RequestCondition, potentialGsiName: Option[String])(using returnTypeFormat: DynamoFormat[U]): IO[List[U]] =
+        if dynamoError then IO.raiseError(new Exception("Error getting dynamo items"))
+        else
+          dynamoItemsRef.get.map { rows =>
+            (for {
+              values <- requestCondition.dynamoValues
+              map <- values.toMap[String].toOption
+            } yield rows
+              .filter(row => map.get("conditionAttributeValue0").contains(row.groupId))
+              .map(_.asInstanceOf[U])).getOrElse(Nil)
+
+          }
+
+      override def getItems[T, K](primaryKeys: List[K], tableName: String)(using returnFormat: DynamoFormat[T], keyFormat: DynamoFormat[K]): IO[List[T]] = IO.pure(Nil)
+
+      override def updateAttributeValues(dynamoDbRequest: DADynamoDBClient.DADynamoDbRequest): IO[Int] = IO(1)
+    }
+
+    val snsClient: DASNSClient[IO] = new DASNSClient[IO]:
+      override def publish[T <: Product](topicArn: String)(messages: List[T])(using enc: Encoder[T]): IO[List[PublishBatchResponse]] =
+        if snsError then IO.raiseError(new Exception("Error sending to SNS"))
+        else
+          snsMessagesRef
+            .update { existingMessages =>
+              existingMessages ++ messages.map(_.asInstanceOf[OutputMessage])
+            }
+            .map(_ => List(PublishBatchResponse.builder.build))
+
+    val uuidIterator: () => UUID = () => {
+      val uuidsIterator: Iterator[UUID] = uuids.iterator
+      uuidsIterator.next()
+    }
+    Dependencies(snsClient, dynamoClient, uuidIterator)
+  }
+
+  def generateItems(): List[IngestLockTableItem] = List.fill(100)(UUID.randomUUID).zipWithIndex.map { (id, idx) =>
+    IngestLockTableItem(id, s"groupId", "")
+  }
+
+  def runLambda(lockTableItems: List[IngestLockTableItem], input: SfnInput, dynamoError: Boolean = false, snsError: Boolean = false): List[OutputMessage] = (for {
+    dynamoItemsRef <- Ref.of[IO, List[IngestLockTableItem]](lockTableItems)
+    snsMessagesRef <- Ref.of[IO, List[OutputMessage]](Nil)
+    dependencies = createDependencies(dynamoItemsRef, snsMessagesRef, dynamoError, snsError)
+    _ <- new Lambda().handler(SfnEvent(SfnDetail(input)), config, dependencies)
+    snsMessages <- snsMessagesRef.get
+  } yield snsMessages).unsafeRunSync()

--- a/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTestUtils.scala
+++ b/scala/lambdas/ingest-failure-notifications/src/test/scala/uk/gov/nationalarchives/ingestfailurenotifications/LambdaTestUtils.scala
@@ -43,7 +43,6 @@ object LambdaTestUtils:
             } yield rows
               .filter(row => map.get("conditionAttributeValue0").contains(row.groupId))
               .map(_.asInstanceOf[U])).getOrElse(Nil)
-
           }
 
       override def getItems[T, K](primaryKeys: List[K], tableName: String)(using returnFormat: DynamoFormat[T], keyFormat: DynamoFormat[K]): IO[List[T]] = IO.pure(Nil)
@@ -68,8 +67,8 @@ object LambdaTestUtils:
     Dependencies(snsClient, dynamoClient, uuidIterator)
   }
 
-  def generateItems(): List[IngestLockTableItem] = List.fill(100)(UUID.randomUUID).zipWithIndex.map { (id, idx) =>
-    IngestLockTableItem(id, s"groupId", "")
+  def generateItems(): List[IngestLockTableItem] = List.fill(100)(UUID.randomUUID).map { id =>
+    IngestLockTableItem(id, "groupId", "")
   }
 
   def runLambda(lockTableItems: List[IngestLockTableItem], input: SfnInput, dynamoError: Boolean = false, snsError: Boolean = false): List[OutputMessage] = (for {

--- a/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/LambdaTest.scala
@@ -10,8 +10,9 @@ import org.scalatest.prop.{TableDrivenPropertyChecks, TableFor4}
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.*
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.Type.*
 import uk.gov.nationalarchives.ingestfileschangehandler.Lambda.*
-import uk.gov.nationalarchives.ingestfileschangehandler.Lambda.MessageType.*
-import uk.gov.nationalarchives.ingestfileschangehandler.Lambda.MessageStatus.*
+import uk.gov.nationalarchives.utils.ExternalUtils.{MessageType, MessageStatus, OutputMessage, OutputProperties, OutputParameters}
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageType.*
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageStatus.*
 import uk.gov.nationalarchives.ingestfileschangehandler.Utils.*
 
 import java.time.Instant

--- a/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/Utils.scala
+++ b/scala/lambdas/ingest-files-change-handler/src/test/scala/uk/gov/nationalarchives/ingestfileschangehandler/Utils.scala
@@ -23,7 +23,7 @@ import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{
   upstreamSystem,
   Checksum
 }
-import uk.gov.nationalarchives.ingestfileschangehandler.Lambda.OutputMessage
+import uk.gov.nationalarchives.utils.ExternalUtils.OutputMessage
 
 import java.net.URI
 import java.time.OffsetDateTime

--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
@@ -8,7 +8,7 @@ import io.circe.generic.auto.*
 import io.circe.parser.decode
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 import uk.gov.nationalarchives.DADynamoDBClient.DADynamoDbWriteItemRequest
-import uk.gov.nationalarchives.utils.EventDecoders.given
+import uk.gov.nationalarchives.utils.EventCodecs.given
 import uk.gov.nationalarchives.ingestparsedcourtdocumenteventhandler.FileProcessor.*
 import uk.gov.nationalarchives.ingestparsedcourtdocumenteventhandler.Lambda.Dependencies
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{assetId, groupId, message}

--- a/scala/lambdas/preservica-config/src/main/scala/uk/gov/nationalarchives/preservicaconfig/Lambda.scala
+++ b/scala/lambdas/preservica-config/src/main/scala/uk/gov/nationalarchives/preservicaconfig/Lambda.scala
@@ -5,7 +5,7 @@ import com.amazonaws.services.lambda.runtime.events.SQSEvent
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import pureconfig.generic.derivation.default.*
 import pureconfig.ConfigReader
-import uk.gov.nationalarchives.utils.EventDecoders.given
+import uk.gov.nationalarchives.utils.EventCodecs.given
 import uk.gov.nationalarchives.preservicaconfig.FileProcessors.*
 import Lambda.{Config, Dependencies}
 import uk.gov.nationalarchives.dp.client.AdminClient

--- a/scala/lambdas/utils/src/main/scala/uk/gov/nationalarchives/utils/EventCodecs.scala
+++ b/scala/lambdas/utils/src/main/scala/uk/gov/nationalarchives/utils/EventCodecs.scala
@@ -2,12 +2,22 @@ package uk.gov.nationalarchives.utils
 
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import com.amazonaws.services.lambda.runtime.events.{SQSEvent, ScheduledEvent}
-import io.circe.{Decoder, HCursor}
+import io.circe.generic.semiauto.deriveEncoder
+import io.circe.{Decoder, Encoder, HCursor, Json}
 import org.joda.time.DateTime
+import uk.gov.nationalarchives.utils.ExternalUtils.*
+import scala.jdk.CollectionConverters.*
 
-import scala.jdk.CollectionConverters._
+object EventCodecs {
+  given Encoder[MessageStatus] = (messageStatus: MessageStatus) => Json.fromString(messageStatus.value)
 
-object EventDecoders {
+  given Encoder[MessageType] = (messageType: MessageType) => Json.fromString(messageType.toString)
+
+  given Encoder[OutputProperties] = deriveEncoder[OutputProperties]
+
+  given Encoder[OutputParameters] = deriveEncoder[OutputParameters]
+
+  given Encoder[OutputMessage] = deriveEncoder[OutputMessage]
 
   given Decoder[ScheduledEvent] = (c: HCursor) =>
     for {

--- a/scala/lambdas/utils/src/main/scala/uk/gov/nationalarchives/utils/ExternalUtils.scala
+++ b/scala/lambdas/utils/src/main/scala/uk/gov/nationalarchives/utils/ExternalUtils.scala
@@ -6,7 +6,7 @@ import io.circe.syntax.*
 import uk.gov.nationalarchives.utils.ExternalUtils.Type.{ArchiveFolder, ContentFolder}
 
 import java.net.URI
-import java.time.OffsetDateTime
+import java.time.{Instant, OffsetDateTime}
 import java.util.UUID
 
 object ExternalUtils {
@@ -169,5 +169,21 @@ object ExternalUtils {
                                  checksumSha256: String
                                ) extends MetadataObject
 
+  enum MessageType:
+    override def toString: String = this match
+      case IngestUpdate => "preserve.digital.asset.ingest.update"
+      case IngestComplete => "preserve.digital.asset.ingest.complete"
 
+    case IngestUpdate, IngestComplete
+
+  enum MessageStatus(val value: String):
+    case IngestedPreservation extends MessageStatus("Asset has been ingested to the Preservation System.")
+    case IngestedCCDisk extends MessageStatus("Asset has been written to custodial copy disk.")
+    case IngestError extends MessageStatus("There has been an error ingesting the asset")
+
+  case class OutputProperties(executionId: String, messageId: UUID, parentMessageId: Option[String], timestamp: Instant, `type`: MessageType)
+
+  case class OutputParameters(assetId: UUID, status: MessageStatus)
+
+  case class OutputMessage(properties: OutputProperties, parameters: OutputParameters)
 }


### PR DESCRIPTION
This lambda will be triggered by the step function failure
notifications.

It first gets the groupId and batchId out of the step function input
which is sent as part of the eventbridge rule. This will work for the
preingest and ingest step functions as they both have these in their
input.

It then looks up that group id in the lock table and for each asset it
finds, it will send an update message saying there has been an error.

I also renamed EventDecoders to EventCodecs as it has encoders now as
well and I moved some of the messaging stuff into utils as there's
multiple things using it now.
