### PR TITLE
Minor copy lambda fixes.

### DIFF
--- a/python/lambdas/copy-files-from-tdr/copy_files_lambda_function_test.py
+++ b/python/lambdas/copy-files-from-tdr/copy_files_lambda_function_test.py
@@ -202,8 +202,8 @@ class TestLambdaFunction(unittest.TestCase):
     def test_should_raise_an_exception_when_the_file_exists_but_corresponding_metadata_file_does_not_exist_in_source_bucket(
             self,
             mock_head_object):
-        def selective_error_object(bucket, key):
-            if key == 'some_key.metadata':
+        def selective_error_object(Bucket, Key):
+            if Key == 'some_key.metadata':
                 error_response = {
                     'Error': {
                         'Code': '404',
@@ -212,7 +212,7 @@ class TestLambdaFunction(unittest.TestCase):
                 }
                 raise ClientError(error_response, 'HeadObject')
             else:
-                return {}
+                return {'ContentLength': 1024}
 
         mock_head_object.side_effect = selective_error_object
         with self.assertRaises(Exception) as ex:

--- a/python/lambdas/copy-files-from-tdr/lambda_function.py
+++ b/python/lambdas/copy-files-from-tdr/lambda_function.py
@@ -33,7 +33,7 @@ def lambda_handler(event, context):
 def assert_objects_exist_in_bucket(source_bucket, files):
     for file in files:
         try:
-            s3_client.head_object(source_bucket, file)
+            s3_client.head_object(Bucket=source_bucket, Key=file)
         except botocore.exceptions.ClientError as ex:
             raise Exception(f"Object '{file}' does not exist in '{source_bucket}', underlying error is: '{ex}'")
 

--- a/python/lambdas/copy-files-from-tdr/requirements-runtime.txt
+++ b/python/lambdas/copy-files-from-tdr/requirements-runtime.txt
@@ -1,2 +1,1 @@
-jsonschema
-boto3
+jsonschema==4.17.3


### PR DESCRIPTION
We were getting an error
` No module named 'rpds.rpds`

This issue comment
https://github.com/aws/aws-cdk/issues/26300#issuecomment-1629842430

says we need to pin the jsonschema import to that version. This has
stopped the error.

Also, head_object in boto3 needs named arguments and I've updated the
tests to reflect this.
