### PR TITLE
Increase role duration.

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -20,6 +20,7 @@ jobs:
       - name: Configure AWS credentials for Lambda
         uses: aws-actions/configure-aws-credentials@v4.0.2
         with:
+          role-duration-seconds: 7200
           role-to-assume: arn:aws:iam::${{ secrets.ACCOUNT_NUMBER }}:role/intg-dr2-run-e2e-tests-role
           aws-region: eu-west-2
           role-session-name: RunE2ETestsRole


### PR DESCRIPTION
The default is 1 hour but the e2e tests take so long to run this isn't
enough. We'll try two hours for now and see how that goes.
