### PR TITLE
Various fixes

### DIFF
--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessor.scala
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/FileProcessor.scala
@@ -245,7 +245,7 @@ object FileProcessor {
 
   case class TREInputParameters(status: String, reference: String, skipSeriesLookup: Boolean, s3Bucket: String, s3Key: String)
 
-  case class TREInput(properties: TREInputProperties, parameters: TREInputParameters)
+  case class TREInput(parameters: TREInputParameters, properties: Option[TREInputProperties] = None)
 
   case class TREMetadata(parameters: TREMetadataParameters)
 

--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/main/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/Lambda.scala
@@ -79,7 +79,7 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
           departmentAndSeries.potentialDepartment,
           departmentAndSeries.potentialSeries,
           tdrUuid,
-          treInput.properties.messageId
+          treInput.properties.flatMap(_.messageId)
         )
         _ <- fileProcessor.createMetadataJson(metadata, metadataPackage)
         _ <- logWithFileRef(s"Copied metadata.json to bucket $outputBucket")
@@ -101,9 +101,11 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
             Some(s"attribute_not_exists($assetId)")
           )
         )
+        groupId = s"COURTDOC_$batchRef"
+        batchId = s"${groupId}_0"
         _ <- logWithFileRef("Written asset to lock table")
 
-        _ <- dependencies.sfn.startExecution(config.sfnArn, new Output(s"${groupId}_0", s"COURTDOC_$batchRef", metadataPackage, 0, config.sfnArn), Option(groupId))
+        _ <- dependencies.sfn.startExecution(config.sfnArn, new Output(batchId, groupId, metadataPackage, 0, config.sfnArn), Option(batchId))
         _ <- logWithFileRef("Started step function execution")
       } yield ()
     }.void

--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/LambdaTest.scala
@@ -162,7 +162,7 @@ class LambdaTest extends AnyFlatSpec with TableDrivenPropertyChecks with EitherV
 
     val (res, _, _, _) = runLambda(initialS3State, eventWithInvalidJson)
 
-    res.left.value.getMessage should equal("DecodingFailure at .properties: Missing required field")
+    res.left.value.getMessage should equal("DecodingFailure at .parameters: Missing required field")
   }
 
   "the lambda" should "error if the json in the metadata file is invalid" in {

--- a/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/TestUtils.scala
+++ b/scala/lambdas/ingest-parsed-court-document-event-handler/src/test/scala/uk/gov/nationalarchives/ingestparsedcourtdocumenteventhandler/TestUtils.scala
@@ -139,8 +139,8 @@ object TestUtils:
     } yield (res, s3FinalState, dynamoFinalState, sfnFinalState)).unsafeRunSync()
 
   def packageAvailable(s3Key: String): TREInput = TREInput(
-    TREInputProperties(None),
-    TREInputParameters("status", "TEST-REFERENCE", skipSeriesLookup = false, inputBucket, s3Key)
+    TREInputParameters("status", "TEST-REFERENCE", skipSeriesLookup = false, inputBucket, s3Key),
+    None
   )
 
   def event(s3Key: String = "test.tar.gz", body: Option[String] = None): SQSEvent = {


### PR DESCRIPTION
The properties object in the TRE message isn't being sent by TRE so this
needs to be optional.

Also, groupId and the step function name were being set to "groupId" and
"groupId_0" which isn't quite right.

This has been tested on integration.
