### PR TITLE
DR2-2004 Don't strip filenames and use description

### DIFF
--- a/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
@@ -31,8 +31,6 @@ import java.util.UUID
 class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
   lazy private val bufferSize = 1024 * 5
 
-  private def stripFileExtension(title: String) = if title.contains(".") then title.substring(0, title.lastIndexOf('.')) else title
-
   override def handler: (Input, Config, Dependencies) => IO[Output] = (input, config, dependencies) => {
 
     def processNonMetadataObjects(
@@ -50,11 +48,11 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
           val assetMetadata = AssetMetadataObject(
             assetId,
             None,
-            stripFileExtension(tdrMetadata.Filename),
+            tdrMetadata.Filename,
             assetId.toString,
             List(fileId),
             List(metadataId),
-            None,
+            tdrMetadata.description,
             tdrMetadata.TransferringBody,
             LocalDateTime.parse(tdrMetadata.TransferInitiatedDatetime.replace(" ", "T")).atOffset(ZoneOffset.UTC),
             "TDR",
@@ -77,7 +75,7 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
                 val fileMetadata = FileMetadataObject(
                   fileId,
                   Option(assetId),
-                  stripFileExtension(tdrMetadata.Filename),
+                  tdrMetadata.Filename,
                   1,
                   tdrMetadata.Filename,
                   headObjectResponse.contentLength(),

--- a/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
@@ -118,7 +118,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
 
       assetMetadataObject.id should equal(tdrFileId)
       assetMetadataObject.parentId should equal(Option(archiveFolderId))
-      assetMetadataObject.title should equal(stripFileExtension(testData.fileName.fileString))
+      assetMetadataObject.title should equal(testData.fileName.fileString)
       assetMetadataObject.name should equal(tdrFileId.toString)
       assetMetadataObject.originalFiles should equal(List(fileId))
       assetMetadataObject.originalMetadataFiles should equal(List(metadataFileId))
@@ -138,7 +138,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
       checkIdField("RecordID", tdrFileId.toString)
 
       fileMetadataObject.parentId should equal(Option(tdrFileId))
-      fileMetadataObject.title should equal(stripFileExtension(testData.fileName.fileString))
+      fileMetadataObject.title should equal(testData.fileName.fileString)
       fileMetadataObject.sortOrder should equal(1)
       fileMetadataObject.name should equal(testData.fileName.fileString)
       fileMetadataObject.fileSize should equal(testData.fileSize)


### PR DESCRIPTION
We don't want to have the file extension stripped and we want to use the
description from TDR when available
