### PR TITLE
Use ubuntu 22.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ permissions:
   contents: write
 jobs:
   pre-deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       next-version: ${{ steps.next-tag.outputs.next-version }}
     steps:
@@ -41,7 +41,7 @@ jobs:
           git push origin ${{ steps.next-tag.outputs.next-version }}
   deploy:
     needs: pre-deploy
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - run: gh workflow run deploy.yml -f environment=intg -f to-deploy=${{ needs.pre-deploy.outputs.next-version }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ permissions:
   contents: write
 jobs:
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: ${{ github.event.inputs.environment }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 jobs:
   run_tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     environment: intg
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
The latest release has removed a lot of tools, one of which is sbt. This
is a temporary solution while we think of a clean way of installing sbt
on every build.
