### PR TITLE
DR2-2117 Aggregator to return list of failures.

### DIFF
--- a/scala/lambdas/preingest-tdr-aggregator/README.md
+++ b/scala/lambdas/preingest-tdr-aggregator/README.md
@@ -42,7 +42,7 @@ The lambda takes an SQS event as the input. The body of the event is:
 
 ## Lambda output
 
-The lambda does not output anything directly. If a new group is created, it will start the ingest step function with
+If a new group is created, the lambda will start the ingest step function with
 this input
 
 ```json
@@ -53,6 +53,23 @@ this input
   "retryCount": 0
 }
 ```
+
+The lambda also returns a batch item response.
+If no incoming messages failed:
+```json
+{ 
+  "batchItemFailures": []
+}
+```
+
+If there are failures:
+```json
+{
+"batchItemFailures": [{ "itemIdentifier": "sqsMessageId" }]
+}
+```
+
+If we report the failures, it prevents AWS from deleting the message which failed so it can be redelivered at another time.
 
 [Link to the infrastructure code](https://github.com/nationalarchives/dr2-terraform-environments)
 

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
@@ -1,15 +1,17 @@
 package uk.gov.nationalarchives.preingesttdraggregator
 
 import cats.Parallel
+import cats.effect.kernel.Outcome
 import cats.effect.std.AtomicCell
 import cats.effect.syntax.all.*
-import cats.effect.{Async, Outcome}
+import cats.effect.Async
 import cats.syntax.all.*
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import io.circe.*
 import io.circe.generic.auto.*
 import io.circe.parser.decode
 import io.circe.syntax.*
-import io.circe.*
 import org.typelevel.log4cats.SelfAwareStructuredLogger
 import org.typelevel.log4cats.slf4j.Slf4jFactory
 import software.amazon.awssdk.services.dynamodb.model.AttributeValue
@@ -32,7 +34,7 @@ trait Aggregator[F[_]]:
   def aggregate(config: Config, atomicCell: AtomicCell[F, Map[String, Group]], messages: List[SQSMessage], remainingTimeInMillis: Int)(using
       Encoder[SFNArguments],
       Decoder[Input]
-  ): F[List[Outcome[F, Throwable, Unit]]]
+  ): F[List[BatchItemFailure]]
 
 object Aggregator:
 
@@ -49,6 +51,8 @@ object Aggregator:
   type Input = NotificationMessage
 
   case class SFNArguments(groupId: GroupId, batchId: BatchId, waitFor: Seconds, retryCount: Int = 0)
+
+  case class AggregatorError(messageId: String) extends Throwable
 
   enum NewGroupReason:
     case NoExistingGroup, ExpiryBeforeLambdaTimeout, MaxGroupSizeExceeded
@@ -93,6 +97,7 @@ object Aggregator:
         Encoder[SFNArguments]
     ): F[GroupId] = {
       def log = logWithReason(sourceId)
+
       val groupExpiryTime: Milliseconds = lambdaTimeoutTime + config.maxSecondaryBatchingWindow.toMilliSeconds
       atomicCell
         .evalUpdateAndGet { groupCache =>
@@ -110,7 +115,7 @@ object Aggregator:
     override def aggregate(config: Config, atomicCell: AtomicCell[F, Map[String, Group]], messages: List[SQSMessage], remainingTimeInMillis: Int)(using
         Encoder[SFNArguments],
         Decoder[Input]
-    ): F[List[Outcome[F, Throwable, Unit]]] = {
+    ): F[List[BatchItemFailure]] = {
       val lambdaTimeoutTime = (Generators().generateInstant.toEpochMilli + remainingTimeInMillis).milliSeconds
       for {
         fibers <- messages.parTraverse { record =>
@@ -118,10 +123,26 @@ object Aggregator:
             groupId <- getNewOrExistingGroupId(atomicCell, config, record.getEventSourceArn, lambdaTimeoutTime)
             input <- Async[F].fromEither(decode[Input](record.getBody))
             _ <- writeToLockTable(input, config, groupId)
-          } yield ()
-          process.start
+          } yield record.getMessageId
+          process.handleErrorWith { err =>
+            logger.error(Map(), err)(err.getMessage) >>
+              Async[F].raiseError(AggregatorError(record.getMessageId))
+          }.start
         }
         results <- fibers.traverse(_.join)
         _ <- logger.info(Map("successes" -> results.count(_.isSuccess).toString, "failures" -> results.count(_.isError).toString))("Aggregation complete")
-      } yield results
+        response <- handleErrors(results)
+      } yield response
+    }
+
+    private def handleErrors(results: List[Outcome[F, Throwable, String]]): F[List[BatchItemFailure]] = {
+      results
+        .traverse {
+          case Outcome.Errored(e) =>
+            e match
+              case AggregatorError(messageId) => BatchItemFailure.builder().withItemIdentifier(messageId).build.some.pure[F]
+              case _ => Async[F].raiseError(new RuntimeException("Unexpected error", e)) // Should never get here but the compiler complains if I don't check.
+          case _ => none[BatchItemFailure].pure[F]
+        }
+        .map(_.flatten)
     }

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Lambda.scala
@@ -4,21 +4,22 @@ import cats.Monoid
 import cats.effect.IO
 import cats.effect.std.AtomicCell
 import cats.effect.unsafe.implicits.global
-import com.amazonaws.services.lambda.runtime.events.SQSEvent
+import com.amazonaws.services.lambda.runtime.events.{SQSBatchResponse, SQSEvent}
 import com.amazonaws.services.lambda.runtime.{Context, RequestHandler}
 import io.circe.generic.auto.*
 import pureconfig.ConfigReader.Result
 import pureconfig.module.catseffect.syntax.*
 import pureconfig.{ConfigCursor, ConfigReader, ConfigSource}
+import uk.gov.nationalarchives.preingesttdraggregator.Duration.*
 import uk.gov.nationalarchives.preingesttdraggregator.Ids.GroupId
 import uk.gov.nationalarchives.preingesttdraggregator.Lambda.*
 import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient}
-import uk.gov.nationalarchives.preingesttdraggregator.Duration.*
+
 import java.net.URI
 import java.time.Instant
 import java.util.UUID
 import scala.jdk.CollectionConverters.*
-class Lambda extends RequestHandler[SQSEvent, Unit]:
+class Lambda extends RequestHandler[SQSEvent, SQSBatchResponse]:
 
   given Monoid[Map[String, Group]] = Monoid.instance(Map.empty, _ ++ _)
 
@@ -28,13 +29,12 @@ class Lambda extends RequestHandler[SQSEvent, Unit]:
   given DASFNClient[IO] = DASFNClient[IO]()
   given DADynamoDBClient[IO] = DADynamoDBClient[IO]()
 
-  override def handleRequest(input: SQSEvent, context: Context): Unit =
-    ConfigSource.default
-      .loadF[IO, Config]()
-      .flatMap { config =>
-        Aggregator[IO].aggregate(config, groupCacheAtomicCell, input.getRecords.asScala.toList, context.getRemainingTimeInMillis)
-      }
-      .unsafeRunSync()
+  override def handleRequest(input: SQSEvent, context: Context): SQSBatchResponse = {
+    for {
+      config <- ConfigSource.default.loadF[IO, Config]()
+      results <- Aggregator[IO].aggregate(config, groupCacheAtomicCell, input.getRecords.asScala.toList, context.getRemainingTimeInMillis)
+    } yield SQSBatchResponse.builder().withBatchItemFailures(results.asJava).build
+  }.unsafeRunSync()
 
 object Lambda:
 

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Lambda.scala
@@ -32,8 +32,8 @@ class Lambda extends RequestHandler[SQSEvent, SQSBatchResponse]:
   override def handleRequest(input: SQSEvent, context: Context): SQSBatchResponse = {
     for {
       config <- ConfigSource.default.loadF[IO, Config]()
-      results <- Aggregator[IO].aggregate(config, groupCacheAtomicCell, input.getRecords.asScala.toList, context.getRemainingTimeInMillis)
-    } yield SQSBatchResponse.builder().withBatchItemFailures(results.asJava).build
+      potentialFailures <- Aggregator[IO].aggregate(config, groupCacheAtomicCell, input.getRecords.asScala.toList, context.getRemainingTimeInMillis)
+    } yield SQSBatchResponse.builder().withBatchItemFailures(potentialFailures.asJava).build
   }.unsafeRunSync()
 
 object Lambda:

--- a/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/AggregatorTest.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/AggregatorTest.scala
@@ -2,7 +2,8 @@ package uk.gov.nationalarchives.preingesttdraggregator
 
 import cats.effect.std.AtomicCell
 import cats.effect.unsafe.implicits.global
-import cats.effect.{IO, Outcome, Ref}
+import cats.effect.{IO, Ref}
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import io.circe.Encoder
 import org.scalatest.flatspec.AnyFlatSpec
@@ -39,11 +40,14 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
 
   case class StartExecutionArgs(stateMachineArn: String, sfnArguments: SFNArguments, name: Option[String])
 
-  def dynamoClient(ref: Ref[IO, List[DADynamoDbWriteItemRequest]], failWrite: Boolean): DADynamoDBClient[IO] = new DADynamoDBClient[IO]:
+  def dynamoClient(ref: Ref[IO, List[DADynamoDbWriteItemRequest]], dynamoErrors: Map[UUID, Boolean]): DADynamoDBClient[IO] = new DADynamoDBClient[IO]:
     override def deleteItems[T](tableName: String, primaryKeyAttributes: List[T])(using DynamoFormat[T]): IO[List[BatchWriteItemResponse]] = IO.pure(Nil)
 
-    override def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): IO[Int] =
-      if failWrite then IO.raiseError(new Exception("Write item failed")) else ref.update(args => dynamoDbWriteRequest :: args).map(_ => 2)
+    override def writeItem(dynamoDbWriteRequest: DADynamoDbWriteItemRequest): IO[Int] = {
+      val assetId = UUID.fromString(dynamoDbWriteRequest.attributeNamesAndValuesToWrite("assetId").s())
+      if dynamoErrors.getOrElse(assetId, false) then IO.raiseError(new Exception("Write item failed"))
+      else ref.update(args => dynamoDbWriteRequest :: args).map(_ => 2)
+    }
 
     override def writeItems[T](tableName: String, items: List[T])(using format: DynamoFormat[T]): IO[List[BatchWriteItemResponse]] = IO.pure(Nil)
 
@@ -95,25 +99,29 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
       else ref.update(args => StartExecutionArgs(stateMachineArn, input.asInstanceOf[SFNArguments], name) :: args).map(_ => StartExecutionResponse.builder.build)
 
   private def getAggregatorOutput(
-      assetId: UUID,
+      assetIds: List[UUID],
       groupMap: Map[String, Group] = Map(),
-      dynamoError: Boolean = false,
+      dynamoErrors: Map[UUID, Boolean] = Map.empty,
       sfnError: Boolean = false
-  ): IO[(List[DADynamoDbWriteItemRequest], List[StartExecutionArgs], Map[String, Group], List[Outcome[IO, Throwable, Unit]])] =
+  ): IO[(List[DADynamoDbWriteItemRequest], List[StartExecutionArgs], Map[String, Group], List[BatchItemFailure])] =
     for {
       writeItemArgsRef <- Ref.of[IO, List[DADynamoDbWriteItemRequest]](Nil)
       startSfnArgsRef <- Ref.of[IO, List[StartExecutionArgs]](Nil)
       groupAtomicCell <- AtomicCell[IO].of[Map[String, Group]](groupMap)
       output <- {
         given DASFNClient[IO] = sfnClient(startSfnArgsRef, sfnError)
-        given DADynamoDBClient[IO] = dynamoClient(writeItemArgsRef, dynamoError)
+        given DADynamoDBClient[IO] = dynamoClient(writeItemArgsRef, dynamoErrors)
         given Generators = generators(instant)
 
-        val sqsMessage = new SQSMessage()
-        sqsMessage.setEventSourceArn("eventSourceArn")
-        sqsMessage.setBody(s"""{"id":"$assetId","location":"s3://bucket/key","messageId":"message-id"}""")
+        val sqsMessages = assetIds.map { assetId =>
+          val sqsMessage = new SQSMessage()
+          sqsMessage.setEventSourceArn("eventSourceArn")
+          sqsMessage.setMessageId(assetId.toString)
+          sqsMessage.setBody(s"""{"id":"$assetId","location":"s3://bucket/key","messageId":"message-id"}""")
+          sqsMessage
+        }
 
-        Aggregator[IO].aggregate(config, groupAtomicCell, List(sqsMessage), 1000)
+        Aggregator[IO].aggregate(config, groupAtomicCell, sqsMessages, 1000)
       }
       writeItemArgs <- writeItemArgsRef.get
       startSfnArgs <- startSfnArgsRef.get
@@ -122,11 +130,11 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
 
   "aggregate" should "add a new group when there is no current group" in {
     val assetId = UUID.randomUUID
-    val output = getAggregatorOutput(assetId)
+    val output = getAggregatorOutput(List(assetId))
 
-    val (writeItemArgs, startSfnArgs, group, results) = output.unsafeRunSync()
+    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
 
-    results.forall(_.isSuccess) should equal(true)
+    failures.isEmpty should equal(true)
     group.size should equal(1)
     checkGroup(group.head._2, groupId, instant.plusMillis(2000), 1)
     checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
@@ -137,11 +145,11 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val assetId = UUID.randomUUID
     val existingGroupId = GroupId("TST")
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, instant, 1))
-    val output = getAggregatorOutput(assetId, groupCache)
+    val output = getAggregatorOutput(List(assetId), groupCache)
 
-    val (writeItemArgs, startSfnArgs, group, results) = output.unsafeRunSync()
+    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
 
-    results.forall(_.isSuccess) should equal(true)
+    failures.isEmpty should equal(true)
     group.size should equal(1)
     checkGroup(group.head._2, groupId, instant.plusMillis(2000), 1)
     checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
@@ -153,11 +161,11 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val existingGroupId = GroupId("TST")
     val later = Instant.now.plusMillis(10000)
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 11))
-    val output = getAggregatorOutput(assetId, groupCache)
+    val output = getAggregatorOutput(List(assetId), groupCache)
 
-    val (writeItemArgs, startSfnArgs, group, results) = output.unsafeRunSync()
+    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
 
-    results.forall(_.isSuccess) should equal(true)
+    failures.isEmpty should equal(true)
     group.size should equal(1)
     checkGroup(group.head._2, groupId, instant.plusMillis(2000), 1)
     checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
@@ -169,35 +177,41 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val existingGroupId = GroupId("TST")
     val later = Instant.now.plusMillis(10000)
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 1))
-    val output = getAggregatorOutput(assetId, groupCache)
+    val output = getAggregatorOutput(List(assetId), groupCache)
 
-    val (writeItemArgs, startSfnArgs, group, results) = output.unsafeRunSync()
+    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
 
-    results.forall(_.isSuccess) should equal(true)
+    failures.isEmpty should equal(true)
     group.size should equal(1)
     checkGroup(group.head._2, existingGroupId, later, 2)
     startSfnArgs.length should equal(0)
     checkWriteItemArgs(writeItemArgs.head, assetId, existingGroupId)
   }
 
-  "aggregate" should "return a failed outcome if the write request returns an error" in {
+  "aggregate" should "return a failed batch item if the write request returns an error" in {
     val assetId = UUID.randomUUID
-    val (_, _, _, results) = getAggregatorOutput(assetId, dynamoError = true).unsafeRunSync()
+    val (_, _, _, results) = getAggregatorOutput(List(assetId), dynamoErrors = Map(assetId -> true)).unsafeRunSync()
 
-    results.head.isError should equal(true)
-    val errorMessage = results.head match
-      case Outcome.Errored(e) => e.getMessage
-      case _                  => ""
-    errorMessage should equal("Write item failed")
+    results.size should equal(1)
+    results.head.getItemIdentifier should equal(assetId.toString)
   }
 
-  "aggregate" should "return a failed outcome if the step function request returns an error" in {
-    val assetId = UUID.randomUUID
-    val (_, _, _, results) = getAggregatorOutput(assetId, sfnError = true).unsafeRunSync()
+  "aggregate" should "return one failed batch item if one of two write requests returns an error" in {
+    val assetIdOne = UUID.randomUUID
+    val assetIdTwo = UUID.randomUUID
+    val (_, _, _, resultsOne) = getAggregatorOutput(List(assetIdOne, assetIdTwo), dynamoErrors = Map(assetIdOne -> true)).unsafeRunSync()
+    resultsOne.size should equal(1)
+    resultsOne.head.getItemIdentifier should equal(assetIdOne.toString)
 
-    results.head.isError should equal(true)
-    val errorMessage = results.head match
-      case Outcome.Errored(e) => e.getMessage
-      case _                  => ""
-    errorMessage should equal("Error starting step function")
+    val (_, _, _, resultsTwo) = getAggregatorOutput(List(assetIdOne, assetIdTwo), dynamoErrors = Map(assetIdTwo -> true)).unsafeRunSync()
+    resultsTwo.size should equal(1)
+    resultsTwo.head.getItemIdentifier should equal(assetIdTwo.toString)
+  }
+
+  "aggregate" should "return a failed batch item if the step function request returns an error" in {
+    val assetId = UUID.randomUUID
+    val (_, _, _, results) = getAggregatorOutput(List(assetId), sfnError = true).unsafeRunSync()
+
+    results.size should equal(1)
+    results.head.getItemIdentifier should equal(assetId.toString)
   }

--- a/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/LambdaTest.scala
@@ -1,0 +1,79 @@
+package uk.gov.nationalarchives.preingesttdraggregator
+
+import cats.effect.IO
+import cats.effect.std.AtomicCell
+import cats.effect.unsafe.implicits.global
+import com.amazonaws.services.lambda.runtime.{ClientContext, CognitoIdentity, Context, LambdaLogger}
+import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure
+import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
+import com.amazonaws.services.lambda.runtime.events.{SQSBatchResponse, SQSEvent}
+import io.circe.{Decoder, Encoder}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers.*
+import uk.gov.nationalarchives.preingesttdraggregator.Aggregator.Input
+import uk.gov.nationalarchives.preingesttdraggregator.Duration.Seconds
+import uk.gov.nationalarchives.preingesttdraggregator.Lambda.Config
+
+import scala.jdk.CollectionConverters.*
+
+class LambdaTest extends AnyFlatSpec {
+
+  private val config = Config("", "", "", Seconds(1), 1)
+
+  "lambda run" should "return the failed messages if there are failures" in {
+    val aggregator = new Aggregator[IO] {
+      override def aggregate(config: Lambda.Config, atomicCell: AtomicCell[IO, Map[String, Lambda.Group]], messages: List[SQSEvent.SQSMessage], remainingTimeInMillis: Int)(using
+          Encoder[Aggregator.SFNArguments],
+          Decoder[Input]
+      ): IO[List[SQSBatchResponse.BatchItemFailure]] =
+        IO.pure(List(BatchItemFailure.builder().withItemIdentifier("identifier").build()))
+    }
+    val response = new Lambda().run(aggregator, sqsEvent, context, config).unsafeRunSync()
+    val itemFailures = response.getBatchItemFailures.asScala
+    itemFailures.size should equal(1)
+    itemFailures.head.getItemIdentifier should equal("identifier")
+  }
+
+  "lambda run" should "return an empty list if there are no failures" in {
+    val aggregator = new Aggregator[IO] {
+      override def aggregate(config: Lambda.Config, atomicCell: AtomicCell[IO, Map[String, Lambda.Group]], messages: List[SQSEvent.SQSMessage], remainingTimeInMillis: Int)(using
+          Encoder[Aggregator.SFNArguments],
+          Decoder[Input]
+      ): IO[List[SQSBatchResponse.BatchItemFailure]] =
+        IO.pure(Nil)
+    }
+    val response = new Lambda().run(aggregator, sqsEvent, context, config).unsafeRunSync()
+    val itemFailures = response.getBatchItemFailures.asScala
+    itemFailures.size should equal(0)
+  }
+
+  private def sqsEvent: SQSEvent = {
+    val sqsMessage = new SQSMessage()
+    val sqsEvent = new SQSEvent()
+    sqsEvent.setRecords(List(sqsMessage).asJava)
+    sqsEvent
+  }
+
+  private def context: Context = new Context:
+    override def getAwsRequestId: String = ""
+
+    override def getLogGroupName: String = ""
+
+    override def getLogStreamName: String = ""
+
+    override def getFunctionName: String = ""
+
+    override def getFunctionVersion: String = ""
+
+    override def getInvokedFunctionArn: String = ""
+
+    override def getIdentity: CognitoIdentity = null
+
+    override def getClientContext: ClientContext = null
+
+    override def getRemainingTimeInMillis: Int = 1
+
+    override def getMemoryLimitInMB: Int = 1
+
+    override def getLogger: LambdaLogger = null
+}


### PR DESCRIPTION
We need to do this
https://docs.aws.amazon.com/lambda/latest/dg/example_serverless_SQS_Lambda_batch_item_failures_section.html

This catches any execption, turns it into a custom case class with the
messageId from the message and then returns that as the result from the
lambda.

I've added some tests to check that we're returning the correct id.
