### PR TITLE
DR2-2130 Only look at events 10 minutes old.

### DIFF
--- a/scala/lambdas/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/entityeventgenerator/Lambda.scala
+++ b/scala/lambdas/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/entityeventgenerator/Lambda.scala
@@ -71,7 +71,7 @@ class Lambda extends LambdaRunner[ScheduledEvent, Int, Config, Dependencies] {
         config.lastEventActionTableName
       )
       updatedSinceResponse = updatedSinceResponses.head
-      updatedSinceAsDate = OffsetDateTime.parse(updatedSinceResponse.datetime).toZonedDateTime.minus(Duration.ofMinutes(10))
+      updatedSinceAsDate = OffsetDateTime.parse(updatedSinceResponse.datetime).toZonedDateTime
       recentlyUpdatedEntities <- entitiesClient.entitiesUpdatedSince(updatedSinceAsDate, startFrom)
       _ <- logger.info(s"There were ${recentlyUpdatedEntities.length} entities updated since $updatedSinceAsDate")
 

--- a/scala/lambdas/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/entityeventgenerator/Lambda.scala
+++ b/scala/lambdas/entity-event-generator-lambda/src/main/scala/uk/gov/nationalarchives/entityeventgenerator/Lambda.scala
@@ -16,7 +16,7 @@ import uk.gov.nationalarchives.dp.client.Entities.Entity
 import uk.gov.nationalarchives.dp.client.EntityClient
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client
 
-import java.time.{Instant, OffsetDateTime}
+import java.time.{Duration, Instant, OffsetDateTime}
 
 class Lambda extends LambdaRunner[ScheduledEvent, Int, Config, Dependencies] {
   private val maxEntitiesPerPage: Int = 1000
@@ -71,7 +71,7 @@ class Lambda extends LambdaRunner[ScheduledEvent, Int, Config, Dependencies] {
         config.lastEventActionTableName
       )
       updatedSinceResponse = updatedSinceResponses.head
-      updatedSinceAsDate = OffsetDateTime.parse(updatedSinceResponse.datetime).toZonedDateTime
+      updatedSinceAsDate = OffsetDateTime.parse(updatedSinceResponse.datetime).toZonedDateTime.minus(Duration.ofMinutes(10))
       recentlyUpdatedEntities <- entitiesClient.entitiesUpdatedSince(updatedSinceAsDate, startFrom)
       _ <- logger.info(s"There were ${recentlyUpdatedEntities.length} entities updated since $updatedSinceAsDate")
 
@@ -83,7 +83,7 @@ class Lambda extends LambdaRunner[ScheduledEvent, Int, Config, Dependencies] {
           }
         } else IO.pure(None)
 
-      _ <- IO.whenA(entityLastEventActionDate.exists(_.isBefore(eventTriggeredDatetime))) {
+      _ <- IO.whenA(entityLastEventActionDate.exists(_.isBefore(eventTriggeredDatetime.minus(Duration.ofMinutes(10))))) {
         for {
           _ <- dASnsDBClient.publish[CompactEntity](config.snsArn)(convertToCompactEntities(recentlyUpdatedEntities.toList))
           updateDateAttributeValue = AttributeValue.builder().s(entityLastEventActionDate.get.toString).build()

--- a/scala/lambdas/entity-event-generator-lambda/src/test/scala/uk/gov/nationalarchives/entityeventgenerator/LambdaSpec.scala
+++ b/scala/lambdas/entity-event-generator-lambda/src/test/scala/uk/gov/nationalarchives/entityeventgenerator/LambdaSpec.scala
@@ -56,6 +56,34 @@ class LambdaSpec extends AnyFlatSpec with EitherValues {
     lambdaResult.value should equal(1)
   }
 
+  "handler" should "not update the datetime or send a message if the date returned is less than 10 minutes before the event triggered date" in {
+    val inputEvent = event("2023-06-06T20:39:59.000000+00:00")
+    val dynamoResponse = List("2023-06-06T20:39:59.000000+00:00")
+    val eventActionTime = "2023-06-06T20:30:00.000000+00:00"
+    val entities = List(generateEntity)
+    val (dynamoResult, snsResult, lambdaResult) = runLambda(inputEvent, entities, List(generateEventAction(eventActionTime)), dynamoResponse)
+
+    dynamoResult.size should equal(1)
+    dynamoResult.head should equal("2023-06-06T20:39:59.000000+00:00")
+    snsResult.size should equal(0)
+    lambdaResult.value should equal(1)
+  }
+
+  "handler" should "update the datetime and send a message if the date returned is just over 10 minutes before the event triggered date" in {
+    val inputEvent = event("2023-06-06T20:40:01.000000+00:00")
+    val dynamoResponse = List("2023-06-06T20:40:01.000000+00:00")
+    val eventActionTime = "2023-06-06T20:30:00.000000+00:00"
+    val entities = List(generateEntity)
+    val (dynamoResult, snsResult, lambdaResult) = runLambda(inputEvent, entities, List(generateEventAction(eventActionTime)), dynamoResponse)
+
+    dynamoResult.head should equal("2023-06-06T20:30Z")
+
+    snsResult.head.deleted should equal(false)
+    snsResult.head.id should equal(s"io:${entities.head.ref}")
+
+    lambdaResult.value should equal(1)
+  }
+
   "handler" should "not update the datetime or send a message if there is an error getting the event actions" in {
     val inputEvent = event("2023-06-07T00:00:00.000000+01:00")
     val dynamoResponse = List("2023-06-06T20:39:53.377170+01:00")


### PR DESCRIPTION
This will now:
* Get the updated since date from Dynamo
* Get entities-updated-since from Preservica for events 10 minutes
  before that time.
* Get the event actions for all entities and get the latest action time.
* If the latest time is before the event action time - 10 minutes, send
  the message.
