### PR TITLE
Update vulnerable dependencies.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,13 +12,13 @@ object Dependencies {
 
   lazy val awsCrt = "software.amazon.awssdk.crt" % "aws-crt" % "0.36.1"
   lazy val awsLambda = "com.amazonaws" % "aws-java-sdk-lambda" % awsLibraryVersion
-  lazy val awsSecretsManager = "com.amazonaws" % "aws-java-sdk-secretsmanager" % awsLibraryVersion
   lazy val catsEffect = "org.typelevel" %% "cats-effect" % "3.5.7"
   lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
   lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeFs2 = "io.circe" %% "circe-fs2" % "0.14.1"
   lazy val commonsCompress = "org.apache.commons" % "commons-compress" % "1.27.1"
+  lazy val awsDynamo = "software.amazon.awssdk" % "dynamodb" % "2.31.1"
   lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % daAwsClientsVersion
   lazy val eventBridgeClient = "uk.gov.nationalarchives" %% "da-eventbridge-client" % daAwsClientsVersion
   lazy val fs2Core = "co.fs2" %% "fs2-core" % fs2Version

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,7 @@ object Dependencies {
   lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
   lazy val circeFs2 = "io.circe" %% "circe-fs2" % "0.14.1"
   lazy val commonsCompress = "org.apache.commons" % "commons-compress" % "1.27.1"
+  lazy val commonsLogging = "commons-logging" % "commons-logging" % "1.3.3"
   lazy val awsDynamo = "software.amazon.awssdk" % "dynamodb" % "2.31.1"
   lazy val dynamoClient = "uk.gov.nationalarchives" %% "da-dynamodb-client" % daAwsClientsVersion
   lazy val eventBridgeClient = "uk.gov.nationalarchives" %% "da-eventbridge-client" % daAwsClientsVersion

--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -48,7 +48,8 @@ lazy val commonSettings = Seq(
     scalaTest % Test,
     wiremock % Test
   ),
-  assembly / assemblyOutputPath := file(s"target/outputs/${name.value}"),
+  dependencyOverrides += awsDynamo,
+    assembly / assemblyOutputPath := file(s"target/outputs/${name.value}"),
   (assembly / assemblyMergeStrategy) := {
     case PathList(ps @ _*) if ps.last == "Log4j2Plugins.dat" => log4j2MergeStrategy
     case _                                                   => MergeStrategy.first
@@ -156,7 +157,6 @@ lazy val entityEventGenerator = (project in file("entity-event-generator-lambda"
   .dependsOn(utils)
   .settings(
     libraryDependencies ++= Seq(
-      awsSecretsManager,
       catsEffect,
       dynamoClient,
       preservicaClient,

--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -48,7 +48,7 @@ lazy val commonSettings = Seq(
     scalaTest % Test,
     wiremock % Test
   ),
-  dependencyOverrides += awsDynamo,
+  dependencyOverrides ++= Seq(awsDynamo, commonsLogging),
     assembly / assemblyOutputPath := file(s"target/outputs/${name.value}"),
   (assembly / assemblyMergeStrategy) := {
     case PathList(ps @ _*) if ps.last == "Log4j2Plugins.dat" => log4j2MergeStrategy


### PR DESCRIPTION
There was an old secrets manager sdk that we're not actually using so
I've removed that.

Also, scanamo is using an old version of the Dynamo library which might
also be a problem so I've overridden that.
