### PR TITLE
DR2-2147 Ignore Discovery API failures

### DIFF
--- a/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
+++ b/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
@@ -186,7 +186,7 @@ class LambdaTest extends AnyFlatSpec {
 
   }
 
-  "handler" should "return an error if the discovery api is unavailable" in {
+  "handler" should "not return an error if the discovery api is unavailable" in {
     val metadataResponse = getMetadata
 
     val dynamoItems = (for {

--- a/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
+++ b/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
@@ -189,16 +189,49 @@ class LambdaTest extends AnyFlatSpec {
   "handler" should "return an error if the discovery api is unavailable" in {
     val metadataResponse = getMetadata
 
-    val ex = intercept[Exception] {
-      (for {
-        s3Ref <- Ref.of[IO, List[S3Object]](List(S3Object("input", "TEST/metadata.json", metadataResponse.metadata)))
-        dynamoRef <- Ref.of[IO, List[Obj]](Nil)
-        deps = dependencies(s3Ref, dynamoRef, discoveryServiceException = true)
-        _ <- new Lambda().handler(input(), config, deps)
-      } yield ()).unsafeRunSync()
-    }
+    val dynamoItems = (for {
+      s3Ref <- Ref.of[IO, List[S3Object]](List(S3Object("input", "TEST/metadata.json", metadataResponse.metadata)))
+      dynamoRef <- Ref.of[IO, List[Obj]](Nil)
+      deps = dependencies(s3Ref, dynamoRef, discoveryServiceException = true)
+      _ <- new Lambda().handler(input(), config, deps)
+      dynamoItems <- dynamoRef.get
+    } yield dynamoItems).unsafeRunSync()
 
-    ex.getMessage should equal("Exception when sending request: GET http://localhost:9015/API/records/v1/collection/A")
+    val departmentId = UUID.fromString(uuids.head)
+    val seriesId = UUID.fromString(uuids.tail.head)
+    val fixedTimeInSeconds = 1712707200
+
+    checkDynamoItems(
+      dynamoItems,
+      DynamoFilesTableItem(
+        "TEST",
+        departmentId,
+        "",
+        "A",
+        ArchiveFolder,
+        "A",
+        "",
+        Some("A"),
+        1,
+        fixedTimeInSeconds
+      )
+    )
+
+    checkDynamoItems(
+      dynamoItems,
+      DynamoFilesTableItem(
+        "TEST",
+        seriesId,
+        departmentId.toString,
+        "A 1",
+        ArchiveFolder,
+        "A 1",
+        "",
+        Some("A 1"),
+        1,
+        fixedTimeInSeconds
+      )
+    )
   }
 
   "handler" should "return an error if the input files are not stored in S3" in {

--- a/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
+++ b/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
@@ -14,6 +14,8 @@ import software.amazon.awssdk.core.async.SdkPublisher
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
 import software.amazon.awssdk.services.s3.model.{DeleteObjectsResponse, HeadObjectResponse, PutObjectResponse}
 import software.amazon.awssdk.transfer.s3.model.{CompletedCopy, CompletedUpload}
+import sttp.client3.impl.cats.CatsMonadAsyncError
+import sttp.client3.testing.SttpBackendStub
 import ujson.Obj
 import uk.gov.nationalarchives.ingestmapper.DiscoveryService.{DepartmentAndSeriesCollectionAssets, DiscoveryCollectionAsset, DiscoveryScopeContent}
 import uk.gov.nationalarchives.ingestmapper.Lambda.{Config, Dependencies, Input}
@@ -140,22 +142,26 @@ object LambdaTestTestUtils extends TableDrivenPropertyChecks {
     Dependencies(metadataService, dynamo, mocks3Client(s3Ref), fixedTime)
   }
 
-  def createDiscoveryService(discoveryServiceException: Boolean, randomUuidGenerator: () => UUID): DiscoveryService[IO] = new DiscoveryService[IO]:
+  def createDiscoveryService(discoveryServiceException: Boolean, randomUuidGenerator: () => UUID): DiscoveryService[IO] =
+    if !discoveryServiceException then
+      new DiscoveryService[IO]:
+        def generateDiscoveryCollectionAsset(col: String): DiscoveryCollectionAsset =
+          DiscoveryCollectionAsset(col, DiscoveryScopeContent(s"TestDescription$col with 0"), s"Test Title $col")
 
-    def generateDiscoveryCollectionAsset(col: String): DiscoveryCollectionAsset =
-      DiscoveryCollectionAsset(col, DiscoveryScopeContent(s"TestDescription$col with 0"), s"Test Title $col")
+        def generateJson: Obj = Obj("id" -> randomUuidGenerator().toString, "type" -> "ArchiveFolder", "name" -> "Test name")
 
-    def generateJson: Obj = Obj("id" -> randomUuidGenerator().toString, "type" -> "ArchiveFolder", "name" -> "Test name")
+        override def getDepartmentAndSeriesItems(batchId: String, departmentAndSeriesAssets: DepartmentAndSeriesCollectionAssets): DepartmentAndSeriesTableItems =
+          DiscoveryService[IO]("baseUrl", randomUuidGenerator).unsafeRunSync().getDepartmentAndSeriesItems(batchId, departmentAndSeriesAssets)
 
-    override def getDepartmentAndSeriesItems(batchId: String, departmentAndSeriesAssets: DepartmentAndSeriesCollectionAssets): DepartmentAndSeriesTableItems =
-      DiscoveryService[IO]("baseUrl", randomUuidGenerator).unsafeRunSync().getDepartmentAndSeriesItems(batchId, departmentAndSeriesAssets)
-
-    override def getDiscoveryCollectionAssets(series: Option[String]): IO[DepartmentAndSeriesCollectionAssets] =
-      if discoveryServiceException then IO.raiseError(new Exception("Exception when sending request: GET http://localhost:9015/API/records/v1/collection/A"))
-      else if series.isEmpty then IO.pure(DepartmentAndSeriesCollectionAssets(None, None))
-      else
-        val department = series.get.split(" ").head
-        IO.pure(DepartmentAndSeriesCollectionAssets(Option(generateDiscoveryCollectionAsset(department)), Option(generateDiscoveryCollectionAsset(series.get))))
+        override def getDiscoveryCollectionAssets(series: Option[String]): IO[DepartmentAndSeriesCollectionAssets] =
+          if discoveryServiceException then IO.raiseError(new Exception("Exception when sending request: GET http://localhost:9015/API/records/v1/collection/A"))
+          else if series.isEmpty then IO.pure(DepartmentAndSeriesCollectionAssets(None, None))
+          else
+            val department = series.get.split(" ").head
+            IO.pure(DepartmentAndSeriesCollectionAssets(Option(generateDiscoveryCollectionAsset(department)), Option(generateDiscoveryCollectionAsset(series.get))))
+    else
+      val backendStub = SttpBackendStub(CatsMonadAsyncError[IO]()).whenAnyRequest.thenRespondServerError()
+      DiscoveryService[IO]("https://example.com", backendStub, randomUuidGenerator)
 
   case class S3Object(bucket: String, key: String, fileContent: String)
 


### PR DESCRIPTION
This catches any errors calling the discovery API and returns the same
object we do if Discovery returns nothing.

I've updated the tests to check for this.
