### PR TITLE
DR2-2191 Fix checksum comparison

### DIFF
--- a/scala/lambdas/ingest-asset-reconciler/src/main/scala/uk/gov/nationalarchives/ingestassetreconciler/Lambda.scala
+++ b/scala/lambdas/ingest-asset-reconciler/src/main/scala/uk/gov/nationalarchives/ingestassetreconciler/Lambda.scala
@@ -65,14 +65,10 @@ class Lambda extends LambdaRunner[Input, StateOutput, Config, Dependencies] {
       titleOfCoWithoutExtension == assetChildTitleOrFileNameWithoutExtension
     }
 
-  private def doesChecksumMatchFixity(item: DynamoFormatters.FileDynamoItem, fixities: List[Client.Fixity]): Boolean = {
-    val sortedChecksums = item.checksums.sortBy(_.algorithm.toUpperCase)
-    val sortedFixities = fixities.sortBy(_.algorithm)
-
-    sortedChecksums.zip(sortedFixities).forall { case (dynamoItemChecksum, preservedFixity) =>
-      dynamoItemChecksum.algorithm.toUpperCase == preservedFixity.algorithm && dynamoItemChecksum.fingerprint == preservedFixity.value
+  private def doesChecksumMatchFixity(item: DynamoFormatters.FileDynamoItem, fixities: List[Client.Fixity]): Boolean =
+    item.checksums.exists { checksum =>
+      fixities.exists(fixity => fixity.algorithm.toLowerCase == checksum.algorithm.toLowerCase && fixity.value == checksum.fingerprint)
     }
-  }
 
   private def verifyFilesInDdbAreInPreservica(
       childrenForRepresentationType: List[FileDynamoItem],

--- a/scala/lambdas/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/ingestassetreconciler/testUtils/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/ingestassetreconciler/testUtils/ExternalServicesTestUtils.scala
@@ -135,7 +135,7 @@ object ExternalServicesTestUtils extends AnyFlatSpec with TableDrivenPropertyChe
     s"${UUID.randomUUID}.json",
     1235,
     "http://localhost/api/entity/content-objects/4dee285b-64e4-49f8-942e-84ab460b5af6/generations/1/bitstreams/1/content",
-    List(Fixity("SHA256", checksum.getOrElse("checksum"))),
+    List(Fixity("SHA256", checksum.getOrElse("checksum")), Fixity("SHA1", checksum.getOrElse("checksum2"))),
     1,
     Original,
     title,


### PR DESCRIPTION
We are comparing checksums like this:

```scala
val sortedChecksums = item.checksums.sortBy(_.algorithm.toUpperCase)
  val sortedFixities = fixities.sortBy(_.algorithm)
  sortedChecksums.zip(sortedFixities).forall { case (dynamoItemChecksum, preservedFixity) =>
    dynamoItemChecksum.algorithm.toUpperCase == preservedFixity.algorithm && dynamoItemChecksum.fingerprint == preservedFixity.value
  }
```

This was working because there was only ever a single checksum from Preservica but now they’re including a SHA1 in the response for the bitstream. What is happening in that code is we’re trying to do:

`sha1FromPreservica == sha256FromDynamo && sha256FromPreservica == sha256FromDynamo`

Which doesn’t work. This would be right if we had a sha1 in Dynamo but we don’t

I’ve changed it to use exists and updated the tests so there is more than one checksum returned from the mock Preservica.

```scala
item.checksums.exists { checksum =>
    fixities.exists(fixity => fixity.algorithm.toLowerCase == checksum.algorithm.toLowerCase && fixity.value == checksum.fingerprint)
  }
```
