### PR TITLE
Update Mapper Lambda Output with groupId

### DIFF
--- a/scala/lambdas/ingest-failure-notifications/README.md
+++ b/scala/lambdas/ingest-failure-notifications/README.md
@@ -1,8 +1,10 @@
 # DR2 Ingest failure notifications
 
+This Lambda is triggered by EventBridge when a step function fails
+
 ## Lambda input
 
-The lambda takes the following input from an EventBridge event:
+The lambda extracts the following input from an EventBridge event:
 
 ```json
 {

--- a/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
+++ b/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/LambdaTest.scala
@@ -27,7 +27,8 @@ class LambdaTest extends AnyFlatSpec {
       s3Objects <- s3Ref.get
     } yield (stateData, s3Objects)).unsafeRunSync()
 
-    stateOutput.batchId should be("TEST")
+    stateOutput.groupId should be("TEST")
+    stateOutput.batchId should be("TEST_0")
     stateOutput.metadataPackage should be(URI.create(s"s3://input/TEST/metadata.json"))
     stateOutput.assets.bucket should be("testInputStateBucket")
     stateOutput.assets.key should be("executionName/assets.json")
@@ -87,7 +88,7 @@ class LambdaTest extends AnyFlatSpec {
       checkDynamoItems(
         dynamoItems,
         DynamoFilesTableItem(
-          "TEST",
+          "TEST_0",
           departmentUuid,
           "",
           expectedDepartment,
@@ -103,7 +104,7 @@ class LambdaTest extends AnyFlatSpec {
         checkDynamoItems(
           dynamoItems,
           DynamoFilesTableItem(
-            "TEST",
+            "TEST_0",
             seriesUuid,
             departmentUuid.toString,
             testResponse.series,
@@ -118,7 +119,7 @@ class LambdaTest extends AnyFlatSpec {
       checkDynamoItems(
         dynamoItems,
         DynamoFilesTableItem(
-          "TEST",
+          "TEST_0",
           folderIdentifier,
           topFolderPath,
           "TestName",
@@ -133,7 +134,7 @@ class LambdaTest extends AnyFlatSpec {
       checkDynamoItems(
         dynamoItems,
         DynamoFilesTableItem(
-          "TEST",
+          "TEST_0",
           assetIdentifier,
           s"$topFolderPath/$folderIdentifier",
           "TestAssetName",
@@ -150,7 +151,7 @@ class LambdaTest extends AnyFlatSpec {
       checkDynamoItems(
         dynamoItems,
         DynamoFilesTableItem(
-          "TEST",
+          "TEST_0",
           docxIdentifier,
           s"$topFolderPath/$folderIdentifier/$assetIdentifier",
           "Test.docx",
@@ -167,7 +168,7 @@ class LambdaTest extends AnyFlatSpec {
       checkDynamoItems(
         dynamoItems,
         DynamoFilesTableItem(
-          "TEST",
+          "TEST_0",
           metadataIdentifier,
           s"$topFolderPath/$folderIdentifier/$assetIdentifier",
           "TEST-metadata.json",
@@ -204,7 +205,7 @@ class LambdaTest extends AnyFlatSpec {
     checkDynamoItems(
       dynamoItems,
       DynamoFilesTableItem(
-        "TEST",
+        "TEST_0",
         departmentId,
         "",
         "A",
@@ -220,7 +221,7 @@ class LambdaTest extends AnyFlatSpec {
     checkDynamoItems(
       dynamoItems,
       DynamoFilesTableItem(
-        "TEST",
+        "TEST_0",
         seriesId,
         departmentId.toString,
         "A 1",

--- a/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
+++ b/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/testUtils/LambdaTestTestUtils.scala
@@ -39,7 +39,7 @@ object LambdaTestTestUtils extends TableDrivenPropertyChecks {
     "0dcc4151-b1d0-44ac-a4a1-5415d7d50d65"
   )
   val config: Config = Config("test", "http://localhost:9015", "testInputStateBucket")
-  def input(s3Prefix: String = "TEST/"): Input = Input("TEST", URI.create(s"s3://$inputBucket/${s3Prefix}metadata.json"), "executionName")
+  def input(s3Prefix: String = "TEST/"): Input = Input("TEST_0", URI.create(s"s3://$inputBucket/${s3Prefix}metadata.json"), "executionName")
 
   def notImplemented[T]: IO[T] = IO.raiseError(new Exception("Not implemented"))
 


### PR DESCRIPTION
Because the failure notifications lambda needs the 'groupId', the workflow step function needs it and because the workflow step function needs it, the Mapper should return it so that it is passed along. The Lambda currently bases the groupId on the batchId but this is only until the step function starts passing it in on its own