### PR TITLE
Rename env vars

### DIFF
--- a/scala/lambdas/postingest-state-change-handler/src/main/resources/application.conf
+++ b/scala/lambdas/postingest-state-change-handler/src/main/resources/application.conf
@@ -1,4 +1,4 @@
-state-table-name = ${POST_INGEST_STATE_DDB_TABLE}
-state-gsi-name = ${POST_INGEST_DDB_TABLE_BATCHPARENT_GSI_NAME}
+state-table-name = ${POSTINGEST_STATE_DDB_TABLE}
+state-gsi-name = ${POSTINGEST_DDB_TABLE_BATCHPARENT_GSI_NAME}
 topic-arn = ${OUTPUT_TOPIC_ARN}
-queues = ${POST_INGEST_QUEUES}
+queues = ${POSTINGEST_QUEUES}


### PR DESCRIPTION
The names have been changed in the terraform but not here so the lambda
doesn't work.
