### PR TITLE
Change dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,10 @@ updates:
       # Check for updates to python packages every week
       interval: "weekly"
   - package-ecosystem: "gradle"
-    directory: "/kotlin"
+    directories: 
+      - "/kotlin/e2etests"
+      - "/kotlin/gradle"
+      - "/kotlin/lib"
     schedule:
       # Check for updates to kotlin packages every week
       interval: "weekly"


### PR DESCRIPTION
Dependabot can't find any gradle files. I don't know if this will help
but it's worth a try.
