### PR TITLE
Entity event generator fixes

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -37,7 +37,7 @@ object Dependencies {
   lazy val log4jSlf4j = "org.apache.logging.log4j" % "log4j-slf4j-impl" % logbackVersion
   lazy val log4jTemplateJson = "org.apache.logging.log4j" % "log4j-layout-template-json" % logbackVersion
   lazy val mockito = "org.scalatestplus" %% "mockito-5-10" % s"$scalaTestVersion.0"
-  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.151"
+  lazy val preservicaClient = "uk.gov.nationalarchives" %% "preservica-client-fs2" % "0.0.152"
   lazy val pureConfigCats = "com.github.pureconfig" %% "pureconfig-cats-effect" % pureConfigVersion
   lazy val pureConfig = "com.github.pureconfig" %% "pureconfig-core" % pureConfigVersion
   lazy val reactorTest = "io.projectreactor" % "reactor-test" % "3.7.9"

--- a/scala/lambdas/custodial-copy-queue-creator/src/test/scala/uk/gov/nationalarchives/custodialcopyqueuecreator/Utils.scala
+++ b/scala/lambdas/custodial-copy-queue-creator/src/test/scala/uk/gov/nationalarchives/custodialcopyqueuecreator/Utils.scala
@@ -12,7 +12,7 @@ import sttp.capabilities.fs2.Fs2Streams
 import uk.gov.nationalarchives.DASQSClient
 import uk.gov.nationalarchives.DASQSClient.FifoQueueConfiguration
 import uk.gov.nationalarchives.dp.client.Entities.Entity
-import uk.gov.nationalarchives.dp.client.EntityClient.{Identifier, StandardEntityMetadata}
+import uk.gov.nationalarchives.dp.client.EntityClient.{EntitiesUpdated, Identifier, StandardEntityMetadata}
 import uk.gov.nationalarchives.dp.client.{Client, DataProcessor, Entities, EntityClient}
 import uk.gov.nationalarchives.custodialcopyqueuecreator.Lambda.*
 
@@ -94,7 +94,7 @@ object Utils:
 
     override def streamBitstreamContent[T](stream: capabilities.Streams[Fs2Streams[IO]])(url: String, streamFn: stream.BinaryStream => IO[T]): IO[T] = IO.pure("".asInstanceOf[T])
 
-    override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[Seq[Entity]] = IO(Nil)
+    override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[EntitiesUpdated] = IO.stub
 
     override def entityEventActions(entity: Entities.Entity, startEntry: Int, maxEntries: Int): IO[Seq[DataProcessor.EventAction]] = IO.pure(Nil)
 

--- a/scala/lambdas/entity-event-generator-lambda/README.md
+++ b/scala/lambdas/entity-event-generator-lambda/README.md
@@ -18,7 +18,7 @@ We are only using the time portion of the event.
 ## Process
 * Get the start value and `LastPolled` date from DynamoDB.
 * Call the `/updated-since` API endpoint with the date and start value from DynamoDB as the parameters.
-* If all entities in the list are deleted entities:
+* If all entities in the list are deleted entities or if there is more than one page of results:
   * Set the last action date to be the same as the `LastPolled` date.
 * If some of the entities are not deleted: 
   * (Since these parameters are ordered by ascending date) get the last entity in the list, excluding any deleted entities.
@@ -26,7 +26,7 @@ We are only using the time portion of the event.
 * If the last action date is after the triggered date from the input json, do nothing.
 * If the last action date is before the triggered date from the input json:
   * Send a message to SNS with the form `{"id":"io:3963e77c-ed9a-4ff7-8960-aa2ca48973af","deleted":false}`
-  * If the last action date is equal to the previous date from DynamoDB, this indicates there are more than 1000 entities with the same updated time or that all returned entities were deleted. Increment the start count by 1.
+  * If the last action date is equal to the previous date from DynamoDB, this indicates there is another page or results or that all returned entities were deleted. Increment the start count by 1000.
   * Store the start count and the last updated time in Dynamo DB and return the number of messages sent to SNS.
   * If the number is more than zero, repeat the process from the second step.
 

--- a/scala/lambdas/entity-event-generator-lambda/src/test/scala/uk/gov/nationalarchives/entityeventgenerator/LambdaSpec.scala
+++ b/scala/lambdas/entity-event-generator-lambda/src/test/scala/uk/gov/nationalarchives/entityeventgenerator/LambdaSpec.scala
@@ -54,7 +54,7 @@ class LambdaSpec extends AnyFlatSpec with EitherValues {
     lambdaResult.value should equal(2)
   }
 
-  "handler" should "not increment the start argument, update the event datetime and send all messages if some entities are deleted" in {
+  "handler" should "not increment the startAt argument, update the event datetime and send all messages if some entities are deleted and there is no next page" in {
     val inputEvent = event("2023-06-07T00:00:00.000000+01:00")
     val dynamoResponse = List("2023-06-06T20:39:53.377170+01:00")
     val eventActionTime = "2023-06-05T00:00:00.000000+01:00"
@@ -68,7 +68,7 @@ class LambdaSpec extends AnyFlatSpec with EitherValues {
     lambdaResult.value should equal(3)
   }
 
-  "handler" should "increment the start number in dynamo if there is another page" in {
+  "handler" should "increment the startAt argument in dynamo if there is another page" in {
     val inputEvent = event("2023-06-07T00:00:00.000000+01:00")
     val eventActionTime = "2023-06-05T00:00:00.000000+01:00"
     val dynamoResponse = List(eventActionTime)
@@ -76,9 +76,11 @@ class LambdaSpec extends AnyFlatSpec with EitherValues {
     val (dynamoResult, snsResult, lambdaResult) = runLambda(inputEvent, entities, List(generateEventAction(eventActionTime)), dynamoResponse)
 
     dynamoResult.head should equal("2023-06-05T00:00+01:00", 1000)
+    snsResult.length should equal(1)
+    lambdaResult.value should equal(1)
   }
 
-  "handler" should "write a start number of 0 if the original start number was 1 and the event action time is after the update since time" in {
+  "handler" should "write a startAt argument of 0 if the original startAt argument was 1 and the event action time is after the event datetime" in {
     val inputEvent = event("2023-06-07T00:00:00.000000+01:00")
     val dynamoResponse = List("2023-06-06T20:39:53.377170+01:00")
     val eventActionTime = "2023-06-05T00:00:00.000000+01:00"

--- a/scala/lambdas/get-latest-preservica-version-lambda/src/test/scala/uk/gov/nationalarchives/getlatestpreservicaversion/testUtils/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/get-latest-preservica-version-lambda/src/test/scala/uk/gov/nationalarchives/getlatestpreservicaversion/testUtils/ExternalServicesTestUtils.scala
@@ -13,7 +13,7 @@ import sttp.capabilities.fs2.Fs2Streams
 import uk.gov.nationalarchives.dp.client.Entities.Entity
 import uk.gov.nationalarchives.{DADynamoDBClient, DAEventBridgeClient}
 import uk.gov.nationalarchives.dp.client.{Client, DataProcessor, Entities, EntityClient}
-import uk.gov.nationalarchives.dp.client.EntityClient.Identifier
+import uk.gov.nationalarchives.dp.client.EntityClient.{EntitiesUpdated, Identifier}
 import uk.gov.nationalarchives.getlatestpreservicaversion.Lambda
 import uk.gov.nationalarchives.getlatestpreservicaversion.Lambda.{Config, Dependencies, Detail, GetDr2PreservicaVersionResponse}
 
@@ -67,7 +67,7 @@ object ExternalServicesTestUtils:
 
     override def streamBitstreamContent[T](stream: capabilities.Streams[Fs2Streams[IO]])(url: String, streamFn: stream.BinaryStream => IO[T]): IO[T] = notImplemented
 
-    override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[Seq[Entity]] = notImplemented
+    override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[EntitiesUpdated] = notImplemented
 
     override def entityEventActions(entity: Entities.Entity, startEntry: Int, maxEntries: Int): IO[Seq[DataProcessor.EventAction]] = notImplemented
 

--- a/scala/lambdas/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/ingestassetreconciler/testUtils/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/ingest-asset-reconciler/src/test/scala/uk/gov/nationalarchives/ingestassetreconciler/testUtils/ExternalServicesTestUtils.scala
@@ -14,7 +14,7 @@ import uk.gov.nationalarchives.dp.client.Client.{BitStreamInfo, Fixity}
 import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse}
 import uk.gov.nationalarchives.dp.client.EntityClient.EntityType.InformationObject
 import uk.gov.nationalarchives.dp.client.EntityClient.GenerationType.Original
-import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntityType, UpdateEntityRequest, Identifier as PreservicaIdentifier}
+import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntitiesUpdated, EntityType, UpdateEntityRequest, Identifier as PreservicaIdentifier}
 import uk.gov.nationalarchives.dp.client.{Client, DataProcessor, Entities, EntityClient}
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{Identifier as DynamoIdentifier, *}
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.Type.*
@@ -98,7 +98,8 @@ object ExternalServicesTestUtils extends AnyFlatSpec with TableDrivenPropertyChe
 
       override def streamBitstreamContent[T](stream: capabilities.Streams[Fs2Streams[IO]])(url: String, streamFn: stream.BinaryStream => IO[T]): IO[T] = notImplemented
 
-      override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[Seq[Entity]] = notImplemented
+      override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[EntitiesUpdated] =
+        notImplemented
 
       override def entityEventActions(entity: Entity, startEntry: Int, maxEntries: Int): IO[Seq[DataProcessor.EventAction]] = notImplemented
 

--- a/scala/lambdas/ingest-find-existing-asset/src/test/scala/uk/gov/nationalarchives/ingestfindexistingasset/testUtils/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/ingest-find-existing-asset/src/test/scala/uk/gov/nationalarchives/ingestfindexistingasset/testUtils/ExternalServicesTestUtils.scala
@@ -11,7 +11,7 @@ import sttp.capabilities
 import sttp.capabilities.fs2.Fs2Streams
 import uk.gov.nationalarchives.DADynamoDBClient
 import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse}
-import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntityType, Identifier, UpdateEntityRequest, Identifier as PreservicaIdentifier}
+import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntitiesUpdated, EntityType, Identifier, UpdateEntityRequest, Identifier as PreservicaIdentifier}
 import uk.gov.nationalarchives.dp.client.EntityClient.SecurityTag.*
 import uk.gov.nationalarchives.dp.client.EntityClient.EntityType.*
 import uk.gov.nationalarchives.dp.client.{Client, DataProcessor, Entities, EntityClient}
@@ -140,7 +140,8 @@ class ExternalServicesTestUtils extends AnyFlatSpec with EitherValues {
 
       override def getPreservicaNamespaceVersion(endpoint: String): IO[Float] = notImplemented
 
-      override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[Seq[Entity]] = notImplemented
+      override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[EntitiesUpdated] =
+        notImplemented
     }
 
   def runLambda(

--- a/scala/lambdas/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/testUtils/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/testUtils/ExternalServicesTestUtils.scala
@@ -14,7 +14,7 @@ import sttp.capabilities.fs2.Fs2Streams
 import uk.gov.nationalarchives.dp.client.Entities.{Entity, IdentifierResponse}
 import uk.gov.nationalarchives.dp.client.EntityClient.EntityType.*
 import uk.gov.nationalarchives.dp.client.EntityClient.SecurityTag.*
-import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntityType, Identifier, UpdateEntityRequest, Identifier as PreservicaIdentifier}
+import uk.gov.nationalarchives.dp.client.EntityClient.{AddEntityRequest, EntitiesUpdated, EntityType, Identifier, UpdateEntityRequest, Identifier as PreservicaIdentifier}
 import uk.gov.nationalarchives.dp.client.{Client, DataProcessor, Entities, EntityClient}
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.Type.*
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{ArchiveFolderDynamoItem, Identifier as DynamoIdentifier}
@@ -109,7 +109,8 @@ class ExternalServicesTestUtils extends AnyFlatSpec with BeforeAndAfterEach with
 
       override def streamBitstreamContent[T](stream: capabilities.Streams[Fs2Streams[IO]])(url: String, streamFn: stream.BinaryStream => IO[T]): IO[T] = notImplemented
 
-      override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[Seq[Entity]] = notImplemented
+      override def entitiesUpdatedSince(sinceDateTime: ZonedDateTime, startEntry: Int, maxEntries: Int, potentialEndDate: Option[ZonedDateTime]): IO[EntitiesUpdated] =
+        notImplemented
 
       override def entityEventActions(entity: Entity, startEntry: Int, maxEntries: Int): IO[Seq[DataProcessor.EventAction]] = notImplemented
 


### PR DESCRIPTION
There are two changes here.

We're now returning `hasNext:Boolean` which shows whether there is
another page. If there is, or all messages are deleted, we keep the next
updated time the same and increment the page.

The other change is to return empty list if the last updated date is
after the event time. This is to stop the lambda recursively trying
again until the event date is later as this is a bit of a waste. Now the
lambda will complete and we can try again on the next invocation.
