### PR TITLE
Make Unknown the default.

### DIFF
--- a/scala/lambdas/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/testUtils/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/ingest-asset-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestassetopexcreator/testUtils/ExternalServicesTestUtils.scala
@@ -168,7 +168,7 @@ object ExternalServicesTestUtils:
           <opex:SourceID>{asset.id}</opex:SourceID>
           <opex:Manifest>
             <opex:Files>
-              <opex:File type="metadata" size="3046">{asset.id}.xip</opex:File>
+              <opex:File type="metadata" size="3055">{asset.id}.xip</opex:File>
               <opex:File type="content" size={fileOne.fileSize.toString}>Representation_Preservation/{fileOne.id}/Generation_1/{fileOne.id}.ext</opex:File>
               <opex:File type="content" size={fileTwo.fileSize.toString}>Representation_Preservation/{fileTwo.id}/Generation_1/{fileTwo.id}.ext</opex:File>
             </opex:Files>
@@ -184,7 +184,7 @@ object ExternalServicesTestUtils:
         <opex:Properties>
           <opex:Title>{asset.id}</opex:Title>
           <opex:Description/>
-          <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+          <opex:SecurityDescriptor>unknown</opex:SecurityDescriptor>
           <opex:Identifiers>
             <opex:Identifier type="UpstreamSystemReference">upstreamSystemReference</opex:Identifier>
           </opex:Identifiers>

--- a/scala/lambdas/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/ingestfolderopexcreator/Lambda.scala
+++ b/scala/lambdas/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/ingestfolderopexcreator/Lambda.scala
@@ -17,6 +17,7 @@ import uk.gov.nationalarchives.{DADynamoDBClient, DAS3Client}
 import uk.gov.nationalarchives.dp.client.fs2.Fs2Client.xmlValidator
 import uk.gov.nationalarchives.ingestfolderopexcreator.Lambda.*
 import uk.gov.nationalarchives.utils.LambdaRunner
+import uk.gov.nationalarchives.dp.client.EntityClient.SecurityTag.*
 
 import java.util.UUID
 import scala.jdk.CollectionConverters.MapHasAsScala
@@ -128,7 +129,7 @@ class Lambda extends LambdaRunner[Input, Unit, Config, Dependencies] {
       _ <- log("File sizes for assets fetched from S3")
 
       folderRows <- IO.pure(childrenWithoutSkip.filter(child => isFolder(child.`type`)))
-      folderOpex <- dependencies.xmlCreator.createFolderOpex(folder, assetRows, folderRows, folder.identifiers)
+      folderOpex <- dependencies.xmlCreator.createFolderOpex(folder, assetRows, folderRows, folder.identifiers, Unknown)
       _ <- xmlValidator(PreservicaSchema.OpexMetadataSchema).xmlStringIsValid("""<?xml version="1.0" encoding="UTF-8"?>""" + folderOpex)
       key = generateKey(input.executionName, folder)
       _ <- uploadXMLToS3(folderOpex, config.bucketName, key)

--- a/scala/lambdas/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/ingestfolderopexcreator/XMLCreator.scala
+++ b/scala/lambdas/ingest-folder-opex-creator/src/main/scala/uk/gov/nationalarchives/ingestfolderopexcreator/XMLCreator.scala
@@ -1,6 +1,7 @@
 package uk.gov.nationalarchives.ingestfolderopexcreator
 
 import cats.effect.IO
+import uk.gov.nationalarchives.dp.client.EntityClient.SecurityTag
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.*
 import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.Type.*
 import uk.gov.nationalarchives.ingestfolderopexcreator.Lambda.{AssetWithFileSize, FolderOrAssetItem}
@@ -13,7 +14,7 @@ class XMLCreator {
       childAssets: List[AssetWithFileSize],
       childFolders: List[FolderOrAssetItem],
       identifiers: List[Identifier],
-      securityDescriptor: String = "open"
+      securityTag: SecurityTag
   ): IO[String] = IO.pure {
     val isHierarchyFolder: Boolean = folder.`type` == ArchiveFolder
     <opex:OPEXMetadata xmlns:opex={opexNamespace}>
@@ -32,7 +33,7 @@ class XMLCreator {
       <opex:Properties>
         <opex:Title>{folder.potentialTitle.getOrElse(folder.name)}</opex:Title>
         <opex:Description>{folder.potentialDescription.getOrElse("")}</opex:Description>
-        <opex:SecurityDescriptor>{securityDescriptor}</opex:SecurityDescriptor>
+        <opex:SecurityDescriptor>{securityTag.toString}</opex:SecurityDescriptor>
         {
       if identifiers.nonEmpty then
         <opex:Identifiers>

--- a/scala/lambdas/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/ExternalServicesTestUtils.scala
+++ b/scala/lambdas/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/ExternalServicesTestUtils.scala
@@ -163,7 +163,7 @@ object ExternalServicesTestUtils:
       <opex:Properties>
         <opex:Title>Test Name</opex:Title>
         <opex:Description></opex:Description>
-        <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+        <opex:SecurityDescriptor>unknown</opex:SecurityDescriptor>
         <opex:Identifiers>
           <opex:Identifier type="Code">Code</opex:Identifier>
         </opex:Identifiers>

--- a/scala/lambdas/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/XMLCreatorTest.scala
+++ b/scala/lambdas/ingest-folder-opex-creator/src/test/scala/uk/gov/nationalarchives/ingestfolderopexcreator/XMLCreatorTest.scala
@@ -9,6 +9,7 @@ import uk.gov.nationalarchives.ingestfolderopexcreator.Lambda.{AssetItem, AssetW
 
 import java.util.UUID
 import scala.xml.Elem
+import uk.gov.nationalarchives.dp.client.EntityClient.SecurityTag.*
 
 class XMLCreatorTest extends AnyFlatSpec {
   private val opexNamespace = "http://www.openpreservationexchange.org/opex/v1.2"
@@ -29,7 +30,7 @@ class XMLCreatorTest extends AnyFlatSpec {
       <opex:Properties>
         <opex:Title>title</opex:Title>
         <opex:Description>description</opex:Description>
-        <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+        <opex:SecurityDescriptor>unknown</opex:SecurityDescriptor>
         [INDENT]
       </opex:Properties>
     </opex:OPEXMetadata>""".replace("[INDENT]", "")
@@ -50,7 +51,7 @@ class XMLCreatorTest extends AnyFlatSpec {
       <opex:Properties>
         <opex:Title>title</opex:Title>
         <opex:Description>description</opex:Description>
-        <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+        <opex:SecurityDescriptor>unknown</opex:SecurityDescriptor>
         <opex:Identifiers>
           <opex:Identifier type="Code">name</opex:Identifier>
         </opex:Identifiers>
@@ -73,7 +74,7 @@ class XMLCreatorTest extends AnyFlatSpec {
       <opex:Properties>
         <opex:Title>name</opex:Title>
         <opex:Description>description</opex:Description>
-        <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+        <opex:SecurityDescriptor>unknown</opex:SecurityDescriptor>
         [INDENT]
       </opex:Properties>
     </opex:OPEXMetadata>""".replace("[INDENT]", "")
@@ -82,7 +83,7 @@ class XMLCreatorTest extends AnyFlatSpec {
   <opex:Properties>
     <opex:Title>name</opex:Title>
     <opex:Description>description</opex:Description>
-    <opex:SecurityDescriptor>open</opex:SecurityDescriptor>
+    <opex:SecurityDescriptor>unknown</opex:SecurityDescriptor>
   </opex:Properties>
   <opex:Transfer>
     <opex:Manifest>
@@ -142,17 +143,17 @@ class XMLCreatorTest extends AnyFlatSpec {
   }
 
   "createFolderOpex" should "create the correct opex xml, excluding the SourceId, if folder type is not 'ArchiveFolder' and there are no identifiers" in {
-    val xml = XMLCreator().createFolderOpex(archiveFolder.copy(`type` = ContentFolder), childAssets, childFolders, Nil).unsafeRunSync()
+    val xml = XMLCreator().createFolderOpex(archiveFolder.copy(`type` = ContentFolder), childAssets, childFolders, Nil, Unknown).unsafeRunSync()
     xml should equal(expectedStandardNonArchiveFolderXml)
   }
 
   "createFolderOpex" should "create the correct opex xml, including the SourceId, if folder type is 'ArchiveFolder' and there are identifiers" in {
-    val xml = XMLCreator().createFolderOpex(archiveFolder, childAssets, childFolders, List(Identifier("Code", "name"))).unsafeRunSync()
+    val xml = XMLCreator().createFolderOpex(archiveFolder, childAssets, childFolders, List(Identifier("Code", "name")), Unknown).unsafeRunSync()
     xml should equal(expectedStandardArchivedFolderXml.toString)
   }
 
   "createFolderOpex" should "create the correct opex xml, using the name if the title is blank" in {
-    val xml = XMLCreator().createFolderOpex(archiveFolder.copy(potentialTitle = None), childAssets, childFolders, Nil).unsafeRunSync()
+    val xml = XMLCreator().createFolderOpex(archiveFolder.copy(potentialTitle = None), childAssets, childFolders, Nil, Unknown).unsafeRunSync()
     xml should equal(expectedXmlNoTitle)
   }
 }

--- a/scala/lambdas/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/LambdaTest.scala
+++ b/scala/lambdas/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/LambdaTest.scala
@@ -160,7 +160,7 @@ class LambdaTest extends ExternalServicesTestUtils with EitherValues {
     err.getMessage should be(s"Security tag 'None' is unexpected for SO ref '${updatedEntity.ref}'")
   }
 
-  "handler" should "return an error if an entity has a security tag which is not open or closed" in {
+  "handler" should "return an error if an entity has a security tag which is not open, closed or unknown" in {
     val folder = generateItem()
     val entityWithIdentifiers = generateEntity(identifierValue = folder.name)
     val updatedEntity = entityWithIdentifiers.entity.copy(securityTag = Some(null))

--- a/scala/lambdas/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/LambdaTest.scala
+++ b/scala/lambdas/ingest-upsert-archive-folders/src/test/scala/uk/gov/nationalarchives/ingestupsertarchivefolders/LambdaTest.scala
@@ -160,7 +160,7 @@ class LambdaTest extends ExternalServicesTestUtils with EitherValues {
     err.getMessage should be(s"Security tag 'None' is unexpected for SO ref '${updatedEntity.ref}'")
   }
 
-  "handler" should "return an error if an entity has a security tag which is not open, closed or unknown" in {
+  "handler" should "return an error if an entity has a security tag which is not open, closed nor unknown" in {
     val folder = generateItem()
     val entityWithIdentifiers = generateEntity(identifierValue = folder.name)
     val updatedEntity = entityWithIdentifiers.entity.copy(securityTag = Some(null))


### PR DESCRIPTION
I missed this the first time because we were passing a default string as
open. I've changed the argument to be the security tag type and removed
the default.
