### PR TITLE
DDSM-400 Roles anywhere

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,9 @@ jobs:
       - run: pip install boto3
       - name: run_plan
         working-directory: terraform
+        env:
+          TF_VAR_site_outbound_subnet: ${{ secrets.kew_proxy_outgoing_ip }}
+          TF_VAR_custodial_copy_x509_subject_cn: ${{ secrets.custodial_copy_x509_subject_cn }}
         run: |
           terraform init
           terraform workspace select $ENVIRONMENT
@@ -91,6 +94,8 @@ jobs:
           python ../.github/scripts/send_message.py
         working-directory: terraform
         env:
+          TF_VAR_site_outbound_subnet: ${{ secrets.kew_proxy_outgoing_ip }}
+          TF_VAR_custodial_copy_x509_subject_cn: ${{ secrets.custodial_copy_x509_subject_cn }}
           MESSAGE: ":white_check_mark: terraform deploy successful for ${{ github.event.inputs.environment }}"
       - run: |
           git tag $TO_DEPLOY

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,1 @@
+kew_proxy_outgoing_ip = "137.221.134.222/32"

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,1 +1,0 @@
-kew_proxy_outgoing_ip = "137.221.134.222/32"

--- a/terraform/custodial_copy.tf
+++ b/terraform/custodial_copy.tf
@@ -3,6 +3,33 @@ locals {
   custodial_copy_db_builder_queue_name = "${local.custodial_copy_name}-db-builder"
 }
 
+module "custodial_copy_user_policy" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_policy?ref=main"
+  name   = local.custodial_copy_name
+  policy_string = templatefile("${path.module}/templates/iam_policy/custodial_copy_policy.json.tpl", {
+    account_id                     = data.aws_caller_identity.current.account_id
+    secrets_manager_secret_arn     = aws_secretsmanager_secret.preservica_read_metadata_read_content.arn
+    custodial_copy_queue           = module.dr2_custodial_copy_queue.sqs_arn
+    custodial_copy_confirmer_queue = module.postingest.postingest_confirmer_queue_arn
+    postingest_table               = module.postingest.postingest_table_arn
+    database_builder_queue         = module.dr2_custodial_copy_db_builder_queue.sqs_arn
+    management_account_id          = module.config.account_numbers["mgmt"]
+  })
+}
+
+module "custodial_copy_profile" {
+  source = "git::https://github.com/nationalarchives/da-terraform-modules//iam_roles_anywhere?ref=main"
+  roles = {
+    local.custodial_copy_name = {
+      # from environment secret
+      x509_subject_cn    = var.custodial_copy_x509_subject_cn
+      policy_attachments = { local.custodial_copy_name = module.custodial_copy_user_policy.policy_arn }
+      # from repository secret
+      allowed_subnets = { "site outbound subnet" = var.site_outbound_subnet }
+    }
+  }
+}
+
 resource "aws_iam_user" "custodial_copy_user" {
   name = local.custodial_copy_name
 }

--- a/terraform/custodial_copy_notifications.tf
+++ b/terraform/custodial_copy_notifications.tf
@@ -6,8 +6,11 @@ locals {
 module "dr2_custodial_copy_topic" {
   source = "git::https://github.com/nationalarchives/da-terraform-modules//sns"
   sns_policy = templatefile("./templates/sns/custodial_copy_topic_policy.json.tpl", {
-    cc_user_arn = aws_iam_user.custodial_copy_user.arn
-    sns_topic   = local.custodial_copy_topic_arn
+    cc_user_arn = flatten([
+      [aws_iam_user.custodial_copy_user.arn],
+      values(module.custodial_copy_profile.roles)[*].role_arn
+    ])
+    sns_topic = local.custodial_copy_topic_arn
   })
   tags       = {}
   topic_name = local.custodial_copy_topic_name


### PR DESCRIPTION
Implement roles anywhere support in dr2 for custodial copy.  The existing IAM user is left in place so this will not have any effect right away; after this is merged and deployed to intg work will be carried out on the uat server to actually use it.  Then later deploy to prod and another PR for cleanup of the iam user