### PR TITLE
DR2-2263 Send IngestStarted message.

### DIFF
--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -370,7 +370,8 @@ lazy val preingestAdHocPackageBuilder = (project in file("preingest-tdr-package-
 
 lazy val aggregatorSettings = libraryDependencies ++= Seq(
   dynamoClient,
-  sfnClient
+  sfnClient,
+  snsClient
 )
 
 lazy val preingestTdrAggregator = (project in file("preingest-tdr-aggregator"))

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
@@ -1,10 +1,10 @@
 package uk.gov.nationalarchives.preingesttdraggregator
 
 import cats.Parallel
+import cats.effect.Async
 import cats.effect.kernel.Outcome
 import cats.effect.std.AtomicCell
 import cats.effect.syntax.all.*
-import cats.effect.Async
 import cats.syntax.all.*
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
@@ -23,10 +23,11 @@ import uk.gov.nationalarchives.preingesttdraggregator.Aggregator.{Input, SFNArgu
 import uk.gov.nationalarchives.preingesttdraggregator.Duration.*
 import uk.gov.nationalarchives.preingesttdraggregator.Ids.*
 import uk.gov.nationalarchives.preingesttdraggregator.Lambda.{Config, Group}
-import uk.gov.nationalarchives.utils.ExternalUtils.NotificationMessage
-import uk.gov.nationalarchives.utils.ExternalUtils.given
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageStatus.IngestStarted
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageType.IngestUpdate
+import uk.gov.nationalarchives.utils.ExternalUtils.{NotificationMessage, OutputMessage, OutputParameters, OutputProperties, given}
 import uk.gov.nationalarchives.utils.Generators
-import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient}
+import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient, DASNSClient}
 
 import java.time.Instant
 import java.util.UUID
@@ -60,7 +61,7 @@ object Aggregator:
   enum NewGroupReason:
     case NoExistingGroup, ExpiryBeforeLambdaTimeout, MaxGroupSizeExceeded
 
-  def apply[F[_]: {Async, Parallel}](sfnClient: DASFNClient[F], dynamoClient: DADynamoDBClient[F])(using Generators): Aggregator[F] =
+  def apply[F[_]: {Async, Parallel}](sfnClient: DASFNClient[F], dynamoClient: DADynamoDBClient[F], snsClient: DASNSClient[F])(using Generators): Aggregator[F] =
     new Aggregator[F]:
       private val logger: SelfAwareStructuredLogger[F] = Slf4jFactory.create[F].getLogger
 
@@ -69,9 +70,15 @@ object Aggregator:
 
       private def toDynamoString(value: String): AttributeValue = AttributeValue.builder.s(value).build
 
-      def writeToLockTable(id: UUID, msgBody: String, config: Config, groupId: GroupId): F[Int] = {
+      def writeToLockTable(id: UUID, msgBody: String, config: Config, groupId: GroupId): F[Unit] = {
+        val batchId = BatchId(groupId)
         val dynamoLockTableItem: DynamoValue = DynamoWriteUtils.writeLockTableItem(
           IngestLockTableItem(id, groupId.groupValue, msgBody, Generators().generateInstant.toString)
+        )
+
+        val outputMessage = OutputMessage(
+          OutputProperties(batchId.batchValue, Generators().generateRandomUuid, None, Instant.now, IngestUpdate),
+          OutputParameters(id, IngestStarted)
         )
 
         dynamoClient.writeItem(
@@ -80,7 +87,7 @@ object Aggregator:
             dynamoLockTableItem.toAttributeValue.m().asScala.toMap,
             Some(s"attribute_not_exists(assetId)")
           )
-        )
+        ) >> snsClient.publish(config.notificationsTopic)(List(outputMessage)).void
       }
 
       private def startNewGroup(config: Config, groupExpiryTime: Milliseconds, id: UUID, msgBody: String)(using enc: Encoder[SFNArguments]): F[Group] = {

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Lambda.scala
@@ -15,7 +15,7 @@ import uk.gov.nationalarchives.preingesttdraggregator.Ids.GroupId
 import uk.gov.nationalarchives.preingesttdraggregator.Lambda.*
 import uk.gov.nationalarchives.utils.ExternalUtils.given
 import uk.gov.nationalarchives.utils.Generators.given
-import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient}
+import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient, DASNSClient}
 
 import java.time.Instant
 import scala.jdk.CollectionConverters.*
@@ -28,7 +28,7 @@ class Lambda extends RequestHandler[SQSEvent, SQSBatchResponse]:
   override def handleRequest(input: SQSEvent, context: Context): SQSBatchResponse = {
     for {
       config <- ConfigSource.default.loadF[IO, Config]()
-      batchResponse <- run(Aggregator[IO](DASFNClient[IO](), DADynamoDBClient[IO]()), input, context, config)
+      batchResponse <- run(Aggregator[IO](DASFNClient[IO](), DADynamoDBClient[IO](), DASNSClient[IO]()), input, context, config)
     } yield batchResponse
   }.unsafeRunSync()
 
@@ -44,4 +44,5 @@ object Lambda:
 
   given ConfigReader[Seconds] = (cur: ConfigCursor) => cur.asInt.map(i => i.seconds)
 
-  case class Config(lockTable: String, sourceSystem: String, sfnArn: String, maxSecondaryBatchingWindow: Seconds, maxBatchSize: Int) derives ConfigReader
+  case class Config(lockTable: String, sourceSystem: String, sfnArn: String, maxSecondaryBatchingWindow: Seconds, maxBatchSize: Int, notificationsTopic: String)
+      derives ConfigReader

--- a/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/AggregatorTest.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/AggregatorTest.scala
@@ -9,8 +9,8 @@ import io.circe.Encoder
 import org.scalatest.flatspec.AnyFlatSpec
 import uk.gov.nationalarchives.preingesttdraggregator.Aggregator.{*, given}
 import uk.gov.nationalarchives.preingesttdraggregator.Duration.*
-import uk.gov.nationalarchives.utils.ExternalUtils.given
-import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient, utils}
+import uk.gov.nationalarchives.utils.ExternalUtils.{OutputMessage, given}
+import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient, DASNSClient, utils}
 import uk.gov.nationalarchives.preingesttdraggregator.Lambda.{Config, Group}
 import io.circe.generic.auto.*
 import org.scalatest.{Assertion, EitherValues}
@@ -19,8 +19,10 @@ import org.scanamo.DynamoFormat
 import org.scanamo.request.RequestCondition
 import software.amazon.awssdk.services.dynamodb.model.BatchWriteItemResponse
 import software.amazon.awssdk.services.sfn.model.StartExecutionResponse
+import software.amazon.awssdk.services.sns.model.PublishBatchResponse
 import uk.gov.nationalarchives.DADynamoDBClient.DADynamoDbWriteItemRequest
-import uk.gov.nationalarchives.preingesttdraggregator.Ids.GroupId
+import uk.gov.nationalarchives.preingesttdraggregator.Ids.{BatchId, GroupId}
+import uk.gov.nationalarchives.utils.ExternalUtils.MessageStatus.IngestStarted
 import uk.gov.nationalarchives.utils.Generators
 
 import java.time.Instant
@@ -32,13 +34,29 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
   def defaultMessageBody(assetId: UUID) = s"""{"id":"$assetId","location":"s3://bucket/key","messageId":"message-id","extraField1":"extraValue1"}"""
   val groupId: GroupId = GroupId("TST", groupUUID)
   val newBatchId = s"${groupId}_0"
-  val config: Config = Config("test-table", "TST", "sfnArn", 1.seconds, 10)
+  val config: Config = Config("test-table", "TST", "sfnArn", 1.seconds, 10, "topicArn")
   given DASFNClient[IO] = DASFNClient[IO]()
   given DADynamoDBClient[IO] = DADynamoDBClient[IO]()
   val instant: Instant = Instant.ofEpochSecond(1723559947)
   def notImplemented[A]: IO[A] = IO.raiseError(new Exception("Not implemented"))
 
   case class StartExecutionArgs(stateMachineArn: String, sfnArguments: SFNArguments, name: Option[String])
+
+  case class AggregatorOutput(
+      dynamoItems: List[DADynamoDbWriteItemRequest],
+      sfnArgs: List[StartExecutionArgs],
+      notificationsMessages: List[OutputMessage],
+      group: Map[String, Group],
+      failures: List[BatchItemFailure]
+  )
+
+  def snsClient(ref: Ref[IO, List[OutputMessage]]): DASNSClient[IO] = new DASNSClient[IO]:
+    override def publish[T <: Product](topicArn: String)(messages: List[T])(using enc: Encoder[T]): IO[List[PublishBatchResponse]] =
+      ref
+        .update { existing =>
+          messages.map(_.asInstanceOf[OutputMessage]) ++ existing
+        }
+        .map(_ => Nil)
 
   def dynamoClient(ref: Ref[IO, List[DADynamoDbWriteItemRequest]], dynamoErrors: Map[UUID, Boolean]): DADynamoDBClient[IO] = new DADynamoDBClient[IO]:
     override def deleteItems[T](tableName: String, primaryKeyAttributes: List[T])(using DynamoFormat[T]): IO[List[BatchWriteItemResponse]] = notImplemented
@@ -60,6 +78,13 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     override def getItems[T, K](primaryKeys: List[K], tableName: String)(using returnFormat: DynamoFormat[T], keyFormat: DynamoFormat[K]): IO[List[T]] = notImplemented
 
     override def updateAttributeValues(dynamoDbRequest: DADynamoDBClient.DADynamoDbRequest): IO[Int] = IO.pure(1)
+
+  def checkSnsMessages(assetId: UUID, batchId: String, messages: List[OutputMessage]): Unit = {
+    messages.length should equal(1)
+    messages.head.parameters.assetId should equal(assetId)
+    messages.head.properties.executionId should equal(batchId)
+    messages.head.parameters.status should equal(IngestStarted)
+  }
 
   def checkGroup(group: Group, groupId: GroupId, instant: Instant, items: Int): Assertion = {
     group.groupId should equal(groupId.groupValue)
@@ -116,14 +141,16 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
       dynamoErrors: Map[UUID, Boolean] = Map.empty,
       sfnError: Boolean = false,
       potentialMessageBody: Option[String] = None
-  ): IO[(List[DADynamoDbWriteItemRequest], List[StartExecutionArgs], Map[String, Group], List[BatchItemFailure])] =
+  ): IO[AggregatorOutput] =
     for {
       writeItemArgsRef <- Ref.of[IO, List[DADynamoDbWriteItemRequest]](Nil)
       startSfnArgsRef <- Ref.of[IO, List[StartExecutionArgs]](Nil)
+      snsMessagesRef <- Ref.of[IO, List[OutputMessage]](Nil)
       groupAtomicCell <- AtomicCell[IO].of[Map[String, Group]](groupMap)
       output <- {
         val daSfnClient: DASFNClient[IO] = sfnClient(startSfnArgsRef, sfnError)
         val daDynamoClient: DADynamoDBClient[IO] = dynamoClient(writeItemArgsRef, dynamoErrors)
+        val daSnsClient: DASNSClient[IO] = snsClient(snsMessagesRef)
 
         given Generators = generators(instant)
 
@@ -135,39 +162,38 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
           sqsMessage
         }
 
-        Aggregator[IO](daSfnClient, daDynamoClient).aggregate(config, groupAtomicCell, sqsMessages, 1000)
+        Aggregator[IO](daSfnClient, daDynamoClient, daSnsClient).aggregate(config, groupAtomicCell, sqsMessages, 1000)
       }
       writeItemArgs <- writeItemArgsRef.get
       startSfnArgs <- startSfnArgsRef.get
+      topicMessages <- snsMessagesRef.get
       group <- groupAtomicCell.get
-    } yield (writeItemArgs, startSfnArgs, group, output)
+    } yield AggregatorOutput(writeItemArgs, startSfnArgs, topicMessages, group, output)
 
   "aggregate" should "add a new group when there is no current group" in {
     val assetId = UUID.randomUUID
-    val output = getAggregatorOutput(List(assetId))
+    val output = getAggregatorOutput(List(assetId)).unsafeRunSync()
 
-    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
-
-    failures.isEmpty should equal(true)
-    group.size should equal(1)
-    checkGroup(group.head._2, groupId, instant.plusMillis(2000), 1)
-    checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
-    checkWriteItemArgs(writeItemArgs, List(assetId), groupId)
+    output.failures.isEmpty should equal(true)
+    output.group.size should equal(1)
+    checkSnsMessages(assetId, newBatchId, output.notificationsMessages)
+    checkGroup(output.group.head._2, groupId, instant.plusMillis(2000), 1)
+    checkSfnArgs(output.sfnArgs.head, newBatchId, groupId)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
   }
 
   "aggregate" should "add a new group to the existing group if the expiry is before the lambda timeout" in {
     val assetId = UUID.randomUUID
     val existingGroupId = GroupId("TST")
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, instant, 1))
-    val output = getAggregatorOutput(List(assetId), groupCache)
+    val output = getAggregatorOutput(List(assetId), groupCache).unsafeRunSync()
 
-    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
-
-    failures.isEmpty should equal(true)
-    group.size should equal(1)
-    checkGroup(group.head._2, groupId, instant.plusMillis(2000), 1)
-    checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
-    checkWriteItemArgs(writeItemArgs, List(assetId), groupId)
+    output.failures.isEmpty should equal(true)
+    output.group.size should equal(1)
+    checkSnsMessages(assetId, newBatchId, output.notificationsMessages)
+    checkGroup(output.group.head._2, groupId, instant.plusMillis(2000), 1)
+    checkSfnArgs(output.sfnArgs.head, newBatchId, groupId)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
   }
 
   "aggregate" should "add a new group to the existing group if the expiry is after the lambda timeout but items is more than max batch size" in {
@@ -175,15 +201,14 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val existingGroupId = GroupId("TST")
     val later = Instant.now.plusMillis(10000)
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 11))
-    val output = getAggregatorOutput(List(assetId), groupCache)
+    val output = getAggregatorOutput(List(assetId), groupCache).unsafeRunSync()
 
-    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
-
-    failures.isEmpty should equal(true)
-    group.size should equal(1)
-    checkGroup(group.head._2, groupId, instant.plusMillis(2000), 1)
-    checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
-    checkWriteItemArgs(writeItemArgs, List(assetId), groupId)
+    output.failures.isEmpty should equal(true)
+    output.group.size should equal(1)
+    checkSnsMessages(assetId, newBatchId, output.notificationsMessages)
+    checkGroup(output.group.head._2, groupId, instant.plusMillis(2000), 1)
+    checkSfnArgs(output.sfnArgs.head, newBatchId, groupId)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
   }
 
   "aggregate" should "update the existing group's 'itemCount' if the expiry is after the lambda timeout and the group is smaller than the max" in {
@@ -191,15 +216,14 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val existingGroupId = GroupId("TST")
     val later = Instant.now.plusMillis(10000)
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 1))
-    val output = getAggregatorOutput(List(assetId), groupCache)
+    val output = getAggregatorOutput(List(assetId), groupCache).unsafeRunSync()
 
-    val (writeItemArgs, startSfnArgs, group, failures) = output.unsafeRunSync()
-
-    failures.isEmpty should equal(true)
-    group.size should equal(1)
-    checkGroup(group.head._2, existingGroupId, later, 2)
-    startSfnArgs.length should equal(0)
-    checkWriteItemArgs(writeItemArgs, List(assetId), existingGroupId)
+    output.failures.isEmpty should equal(true)
+    output.group.size should equal(1)
+    checkSnsMessages(assetId, BatchId(existingGroupId).batchValue, output.notificationsMessages)
+    checkGroup(output.group.head._2, existingGroupId, later, 2)
+    output.sfnArgs.length should equal(0)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), existingGroupId)
   }
 
   "aggregate" should "return a failed batch item if the write request returns an error" in {
@@ -207,13 +231,14 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val existingGroupId = GroupId("TST")
     val later = Instant.now.plusMillis(10000)
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 1))
-    val (writeItemArgs, _, group, results) = getAggregatorOutput(List(assetId), groupCache, dynamoErrors = Map(assetId -> true)).unsafeRunSync()
+    val output = getAggregatorOutput(List(assetId), groupCache, dynamoErrors = Map(assetId -> true)).unsafeRunSync()
 
-    checkWriteItemArgs(writeItemArgs, List(assetId), existingGroupId)
-    group.size should equal(1)
-    checkGroup(group.head._2, existingGroupId, later, 1)
-    results.size should equal(1)
-    results.head.getItemIdentifier should equal(assetId.toString)
+    output.notificationsMessages.length should equal(0)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), existingGroupId)
+    output.group.size should equal(1)
+    checkGroup(output.group.head._2, existingGroupId, later, 1)
+    output.failures.size should equal(1)
+    output.failures.head.getItemIdentifier should equal(assetId.toString)
   }
 
   "aggregate" should "return one failed batch item if one of two write requests returns an error" in {
@@ -224,18 +249,20 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val later = Instant.now.plusMillis(10000)
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 1))
 
-    val (writeItemArgs, _, group, resultsOne) = getAggregatorOutput(List(assetIdOne, assetIdTwo), groupCache, dynamoErrors = Map(assetIdOne -> true)).unsafeRunSync()
-    writeItemArgs.size should equal(2)
-    checkWriteItemArgs(writeItemArgs, List(assetIdOne, assetIdTwo), existingGroupId)
-    resultsOne.size should equal(1)
-    resultsOne.head.getItemIdentifier should equal(assetIdOne.toString)
+    val output = getAggregatorOutput(List(assetIdOne, assetIdTwo), groupCache, dynamoErrors = Map(assetIdOne -> true)).unsafeRunSync()
+    output.dynamoItems.size should equal(2)
+    checkWriteItemArgs(output.dynamoItems, List(assetIdOne, assetIdTwo), existingGroupId)
+    output.failures.size should equal(1)
+    output.failures.head.getItemIdentifier should equal(assetIdOne.toString)
+    checkSnsMessages(assetIdTwo, BatchId(existingGroupId).batchValue, output.notificationsMessages)
 
-    val (writeItemArgs2, _, group2, resultsTwo) = getAggregatorOutput(List(assetIdOne, assetIdTwo), groupCache, dynamoErrors = Map(assetIdTwo -> true)).unsafeRunSync()
-    checkWriteItemArgs(writeItemArgs, List(assetIdOne, assetIdTwo), existingGroupId)
-    group2.size should equal(1)
-    checkGroup(group2.head._2, existingGroupId, later, 2)
-    resultsTwo.size should equal(1)
-    resultsTwo.head.getItemIdentifier should equal(assetIdTwo.toString)
+    val outputTwo = getAggregatorOutput(List(assetIdOne, assetIdTwo), groupCache, dynamoErrors = Map(assetIdTwo -> true)).unsafeRunSync()
+    checkWriteItemArgs(outputTwo.dynamoItems, List(assetIdOne, assetIdTwo), existingGroupId)
+    outputTwo.group.size should equal(1)
+    checkGroup(outputTwo.group.head._2, existingGroupId, later, 2)
+    outputTwo.failures.size should equal(1)
+    outputTwo.failures.head.getItemIdentifier should equal(assetIdTwo.toString)
+    checkSnsMessages(assetIdOne, BatchId(existingGroupId).batchValue, outputTwo.notificationsMessages)
   }
 
   "aggregate" should "return a failed batch item if the step function request returns an error" in {
@@ -244,13 +271,14 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val later = Instant.now
     val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 11))
 
-    val (writeItemArgs, startSfnArgs, group, results) = getAggregatorOutput(List(assetId), groupCache, sfnError = true).unsafeRunSync()
-    checkWriteItemArgs(writeItemArgs, List(assetId), groupId)
-    checkSfnArgs(startSfnArgs.head, newBatchId, groupId)
-    group.size should equal(1)
-    checkGroup(group.head._2, existingGroupId, later, 11)
-    results.size should equal(1)
-    results.head.getItemIdentifier should equal(assetId.toString)
+    val output = getAggregatorOutput(List(assetId), groupCache, sfnError = true).unsafeRunSync()
+    checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
+    checkSfnArgs(output.sfnArgs.head, newBatchId, groupId)
+    output.group.size should equal(1)
+    checkGroup(output.group.head._2, existingGroupId, later, 11)
+    output.failures.size should equal(1)
+    output.failures.head.getItemIdentifier should equal(assetId.toString)
+    checkSnsMessages(assetId, newBatchId, output.notificationsMessages)
   }
 
   "aggregate" should "error if the incoming message doesn't have an id and location" in {
@@ -259,9 +287,9 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     val missingIdOutput = getAggregatorOutput(List(assetId), potentialMessageBody = Option(s"""{"location":"s3://product/key"}"""))
     val emptyOutput = getAggregatorOutput(List(assetId), potentialMessageBody = Option(s"""{}"""))
 
-    val (_, _, _, missingLocationFailures) = missingLocationOutput.unsafeRunSync()
-    val (_, _, _, missingIdFailures) = missingIdOutput.unsafeRunSync()
-    val (_, _, _, emptyFailures) = emptyOutput.unsafeRunSync()
+    val missingLocationFailures = missingLocationOutput.unsafeRunSync().failures
+    val missingIdFailures = missingIdOutput.unsafeRunSync().failures
+    val emptyFailures = emptyOutput.unsafeRunSync().failures
 
     missingLocationFailures.length should equal(1)
     missingIdFailures.length should equal(1)

--- a/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/LambdaTest.scala
@@ -18,7 +18,7 @@ import scala.jdk.CollectionConverters.*
 
 class LambdaTest extends AnyFlatSpec {
 
-  private val config = Config("", "", "", Seconds(1), 1)
+  private val config = Config("", "", "", Seconds(1), 1, "")
 
   "lambda run" should "return the failed messages if there are failures" in {
     val aggregator = new Aggregator[IO] {

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,10 +1,30 @@
 # This file is maintained automatically by "terraform init".
 # Manual edits may be lost in future updates.
 
+provider "registry.terraform.io/hashicorp/archive" {
+  version = "2.7.1"
+  hashes = [
+    "h1:62VrkalDPMKB9zerCBS4iKTbvxejwnAWn/XXYZZQWD4=",
+    "zh:19881bb356a4a656a865f48aee70c0b8a03c35951b7799b6113883f67f196e8e",
+    "zh:2fcfbf6318dd514863268b09bbe19bfc958339c636bcbcc3664b45f2b8bf5cc6",
+    "zh:3323ab9a504ce0a115c28e64d0739369fe85151291a2ce480d51ccbb0c381ac5",
+    "zh:362674746fb3da3ab9bd4e70c75a3cdd9801a6cf258991102e2c46669cf68e19",
+    "zh:7140a46d748fdd12212161445c46bbbf30a3f4586c6ac97dd497f0c2565fe949",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:875e6ce78b10f73b1efc849bfcc7af3a28c83a52f878f503bb22776f71d79521",
+    "zh:b872c6ed24e38428d817ebfb214da69ea7eefc2c38e5a774db2ccd58e54d3a22",
+    "zh:cd6a44f731c1633ae5d37662af86e7b01ae4c96eb8b04144255824c3f350392d",
+    "zh:e0600f5e8da12710b0c52d6df0ba147a5486427c1a2cc78f31eea37a47ee1b07",
+    "zh:f21b2e2563bbb1e44e73557bcd6cdbc1ceb369d471049c40eb56cb84b6317a60",
+    "zh:f752829eba1cc04a479cf7ae7271526b402e206d5bcf1fcce9f535de5ff9e4e6",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/aws" {
   version = "6.41.0"
   hashes = [
     "h1:1FXO2hJl4cpcT7FAfI5ArdtU1fJL8PWEHPF7x/o6BkY=",
+    "h1:iFwjmQtc0tIkSpB1KL+LcqLfuR6KYIGs49ea+LdVXXQ=",
     "zh:01835476adda6d93095e37fdf782f14e6709f6922dc62e88994f9684627deb69",
     "zh:0b9bc5eda9def53df19e1a37562dcb67c1fba8452803e1b5601e75653c986255",
     "zh:196f81d97ea2951d2c6667709445d7c36b5fd8603890c774495806b4da0743aa",
@@ -26,6 +46,7 @@ provider "registry.terraform.io/hashicorp/aws" {
 provider "registry.terraform.io/hashicorp/http" {
   version = "3.5.0"
   hashes = [
+    "h1:8bUoPwS4hahOvzCBj6b04ObLVFXCEmEN8T/5eOHmWOM=",
     "h1:MAWWGNvepa09m3Gy55OBAPk3dhCv6HnjywnKuD70ZBE=",
     "zh:047c5b4920751b13425efe0d011b3a23a3be97d02d9c0e3c60985521c9c456b7",
     "zh:157866f700470207561f6d032d344916b82268ecd0cf8174fb11c0674c8d0736",
@@ -45,6 +66,7 @@ provider "registry.terraform.io/hashicorp/http" {
 provider "registry.terraform.io/hashicorp/random" {
   version = "3.8.1"
   hashes = [
+    "h1:Eexl06+6J+s75uD46+WnZtpJZYRVUMB0AiuPBifK6Jc=",
     "h1:osH3aBqEARwOz3VBJKdpFKJJCNIdgRC6k8vPojkLmlY=",
     "zh:08dd03b918c7b55713026037c5400c48af5b9f468f483463321bd18e17b907b4",
     "zh:0eee654a5542dc1d41920bbf2419032d6f0d5625b03bd81339e5b33394a3e0ae",

--- a/terraform/preingest.tf
+++ b/terraform/preingest.tf
@@ -17,6 +17,7 @@ module "tdr_preingest" {
   private_subnet_ids         = module.vpc.private_subnets
   vpc_id                     = module.vpc.vpc.id
   vpc_arn                    = module.vpc.vpc.arn
+  notifications_topic_arn    = module.dr2_notifications_sns.sns_arn
 }
 
 module "dri_preingest" {
@@ -35,6 +36,7 @@ module "dri_preingest" {
   vpc_id                                       = module.vpc.vpc.id
   vpc_arn                                      = module.vpc.vpc.arn
   delete_from_source                           = true
+  notifications_topic_arn                      = module.dr2_notifications_sns.sns_arn
 }
 
 module "ad_hoc_preingest" {
@@ -53,6 +55,7 @@ module "ad_hoc_preingest" {
   vpc_id                                       = module.vpc.vpc.id
   vpc_arn                                      = module.vpc.vpc.arn
   delete_from_source                           = true
+  notifications_topic_arn                      = module.dr2_notifications_sns.sns_arn
 }
 
 module "court_document_preingest" {
@@ -82,8 +85,9 @@ module "court_document_preingest" {
   package_builder_lambda = {
     handler = "uk.gov.nationalarchives.preingestcourtdocpackagebuilder.Lambda::handleRequest"
   }
-  vpc_id  = module.vpc.vpc.id
-  vpc_arn = module.vpc.vpc.arn
+  vpc_id                  = module.vpc.vpc.id
+  vpc_arn                 = module.vpc.vpc.arn
+  notifications_topic_arn = module.dr2_notifications_sns.sns_arn
 }
 
 module "cc_restore_preingest" {
@@ -105,7 +109,8 @@ module "cc_restore_preingest" {
   package_builder_lambda = {
     handler = "uk.gov.nationalarchives.preingestrestorepackagebuilder.Lambda::handleRequest"
   }
-  vpc_id  = module.vpc.vpc.id
-  vpc_arn = module.vpc.vpc.arn
+  vpc_id                  = module.vpc.vpc.id
+  vpc_arn                 = module.vpc.vpc.arn
+  notifications_topic_arn = module.dr2_notifications_sns.sns_arn
 }
 

--- a/terraform/preingest/preingest.tf
+++ b/terraform/preingest/preingest.tf
@@ -56,6 +56,7 @@ module "dr2_preingest_aggregator_lambda" {
       dynamo_db_lock_table_arn   = var.ingest_lock_table_arn
       preingest_sfn_arn          = local.preingest_sfn_arn
       preingest_aggregator_queue = local.aggregator_queue_arn
+      sns_topic                  = var.notifications_topic_arn
     })
   }
   memory_size = local.java_lambda_memory_size

--- a/terraform/preingest/templates/preingest_aggregator_policy.json.tpl
+++ b/terraform/preingest/templates/preingest_aggregator_policy.json.tpl
@@ -15,6 +15,16 @@
     },
     {
       "Action": [
+        "sns:Publish"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "${sns_topic}"
+      ],
+      "Sid": "publishToNotificationsTopic"
+    },
+    {
+      "Action": [
         "logs:PutLogEvents",
         "logs:CreateLogStream",
         "logs:CreateLogGroup"

--- a/terraform/preingest/variables.tf
+++ b/terraform/preingest/variables.tf
@@ -88,3 +88,5 @@ variable "delete_from_source" {
   description = "Whether to delete the files and metadata from the source bucket"
   default     = false
 }
+
+variable "notifications_topic_arn" {}


### PR DESCRIPTION
This will send an IngestStarted update message directly after the item
is written to the lock table. This means that it's possible for us to
send an IngestStarted message and then the step function invocation
fails. This is fine.

I've changed the tests slightly so the helper method returns a case
class.
