### PR TITLE
DR2-2777 Only return count of items.

### DIFF
--- a/terraform/templates/sfn/ingest_sfn_definition.json.tpl
+++ b/terraform/templates/sfn/ingest_sfn_definition.json.tpl
@@ -293,6 +293,7 @@
         "TableName": "${ingest_lock_table_name}",
         "IndexName": "${ingest_lock_table_group_id_gsi_name}",
         "KeyConditionExpression": "groupId = :lookUpId",
+        "Select": "COUNT",
         "ExpressionAttributeValues": {
           ":lookUpId": {
             "S.$": "$$.Execution.Input.groupId"


### PR DESCRIPTION
If there are a large number of items in the lock table, this query
originally returns them all which exceeds the size for the state data in
the step.

By adding [Select=COUNT](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_Query.html#DDB-Query-request-Select)
this will only return the Count parameter we need and not the items
themselves.
