### PR TITLE
DR2-2786 Add wiz org role to records metadata key.

### DIFF
--- a/terraform/records_metadata.tf
+++ b/terraform/records_metadata.tf
@@ -7,6 +7,7 @@ module "dr2_records_metadata_key" {
   default_policy_variables = {
     ci_roles = [local.terraform_role_arn],
     user_roles = [
+      data.aws_iam_role.org_wiz_access_role.arn,
       data.aws_ssm_parameter.dev_admin_role.value
     ]
   }


### PR DESCRIPTION
Wiz can't scan this bucket as its role hasn't been added to the KMS key.
