### PR TITLE
Use custom encoders

### DIFF
--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
@@ -52,7 +52,7 @@ object Aggregator:
         ("retryCount", Json.fromInt(a.retryCount))
       )
     )
-    
+
   given Decoder[Input] = deriveDecoder[Input]
 
   type Input = NotificationMessage

--- a/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/main/scala/uk/gov/nationalarchives/preingesttdraggregator/Aggregator.scala
@@ -9,7 +9,7 @@ import cats.syntax.all.*
 import com.amazonaws.services.lambda.runtime.events.SQSBatchResponse.BatchItemFailure
 import com.amazonaws.services.lambda.runtime.events.SQSEvent.SQSMessage
 import io.circe.*
-import io.circe.generic.auto.*
+import io.circe.generic.semiauto.deriveDecoder
 import io.circe.parser.decode
 import org.scanamo.DynamoValue
 import org.typelevel.log4cats.SelfAwareStructuredLogger
@@ -24,6 +24,7 @@ import uk.gov.nationalarchives.preingesttdraggregator.Duration.*
 import uk.gov.nationalarchives.preingesttdraggregator.Ids.*
 import uk.gov.nationalarchives.preingesttdraggregator.Lambda.{Config, Group}
 import uk.gov.nationalarchives.utils.ExternalUtils.MessageStatus.IngestStarted
+import uk.gov.nationalarchives.utils.EventCodecs.given
 import uk.gov.nationalarchives.utils.ExternalUtils.MessageType.IngestUpdate
 import uk.gov.nationalarchives.utils.ExternalUtils.{NotificationMessage, OutputMessage, OutputParameters, OutputProperties, given}
 import uk.gov.nationalarchives.utils.Generators
@@ -51,6 +52,8 @@ object Aggregator:
         ("retryCount", Json.fromInt(a.retryCount))
       )
     )
+    
+  given Decoder[Input] = deriveDecoder[Input]
 
   type Input = NotificationMessage
 

--- a/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/AggregatorTest.scala
+++ b/scala/lambdas/preingest-tdr-aggregator/src/test/scala/uk/gov/nationalarchives/preingesttdraggregator/AggregatorTest.scala
@@ -9,10 +9,9 @@ import io.circe.Encoder
 import org.scalatest.flatspec.AnyFlatSpec
 import uk.gov.nationalarchives.preingesttdraggregator.Aggregator.{*, given}
 import uk.gov.nationalarchives.preingesttdraggregator.Duration.*
-import uk.gov.nationalarchives.utils.ExternalUtils.{OutputMessage, given}
+import uk.gov.nationalarchives.utils.ExternalUtils.OutputMessage
 import uk.gov.nationalarchives.{DADynamoDBClient, DASFNClient, DASNSClient, utils}
 import uk.gov.nationalarchives.preingesttdraggregator.Lambda.{Config, Group}
-import io.circe.generic.auto.*
 import org.scalatest.{Assertion, EitherValues}
 import org.scalatest.matchers.should.Matchers.*
 import org.scanamo.DynamoFormat


### PR DESCRIPTION
We were using the generic encoders which encode the enums as objects
instead of as strings. This is now using the correct encoder.
