### PR TITLE
Add lifecyle rule to delete delete object markers.

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -443,6 +443,13 @@ module "ingest_raw_cache_bucket" {
         }
       },
       {
+        id     = "delete-expired-delete-markers"
+        status = "Enabled",
+        expiration = {
+          expired_object_delete_marker = true
+        }
+      },
+      {
         id     = "delete-noncurrent-versions-after-seven-days"
         status = "Enabled"
         noncurrent_version_expiration = {


### PR DESCRIPTION
There are ~400000 delete object markers in this bucket which it would be
nice to get rid of.
