### PR TITLE
DR2-2822 Add GetObjectTagging.

### DIFF
--- a/terraform/preingest/importer.tf
+++ b/terraform/preingest/importer.tf
@@ -5,7 +5,7 @@ locals {
   sse_encryption            = "sse"
   visibility_timeout        = 180
   redrive_maximum_receives  = 5
-  source_bucket_permissions = jsonencode(var.delete_from_source ? ["s3:GetObject", "s3:ListBucket", "s3:DeleteObject"] : ["s3:GetObject", "s3:ListBucket"])
+  source_bucket_permissions = jsonencode(var.delete_from_source ? ["s3:GetObject", "s3:GetObjectTagging", "s3:ListBucket", "s3:DeleteObject"] : ["s3:GetObject", "s3:GetObjectTagging", "s3:ListBucket"])
 }
 module "dr2_importer_lambda" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"


### PR DESCRIPTION
TDR are adding tags to the export objects before we copy them.
Their bucket policy already has GetObjectTagging, it just needs to be
added in here. The policy already has PutObject* on the raw cache bucket
so the put will work.

This will update the other preingest policies as well but I think we can
live with that.
