### PR TITLE
Minor changes for intelligent caching

### DIFF
--- a/python/dri-migration/create_ingest_metadata_test.py
+++ b/python/dri-migration/create_ingest_metadata_test.py
@@ -61,7 +61,7 @@ def verify_function_calls(test: "TestMigrate", is_test_run, get_clients: Mock, m
             mock_checksum.assert_not_called()
 
         write_to_ic_args = write_to_ic_db.call_args_list[0][0]
-        path = "/test/" if is_test_run else ""
+        path = "/test/" if is_test_run else "dri/a/1/test/"
         test.assertEqual([("fileid-xyz", f"{path}file1", "uuid-abc"), ("fileid-xyz", f"{path}file2", "uuid-def")],
                          write_to_ic_args[0])
         test.assertEqual(True, isinstance(write_to_ic_args[1], sqlite3.Connection))

--- a/python/dri-migration/migrate/create_ingest_metadata.py
+++ b/python/dri-migration/migrate/create_ingest_metadata.py
@@ -100,6 +100,7 @@ def migrate(ic_db_path):
     oracledb.init_oracle_client(lib_dir=os.environ['CLIENT_LOCATION'])
     conn = oracledb.connect(dsn=f'{database_host}/SDB4', user="STORE", password=os.environ['STORE_PASSWORD'])
     cur = conn.cursor()
+    cur.execute("SET TRANSACTION READ ONLY")
 
     with open("ingest_query.sql") as query:
         sql = query.read()
@@ -177,14 +178,17 @@ def migrate(ic_db_path):
             file_id = metadata['fileId']
             all_metadata.append(metadata)
             if test_run:
+                base_file_path = file_path
                 upload_file_path = file_path
             elif os.name == "nt":
-                upload_file_path = PureWindowsPath(os.environ['NETWORK_LOCATION'], file_path[1:])
+                base_file_path = file_path[1:]
+                upload_file_path = PureWindowsPath(os.environ['NETWORK_LOCATION'], base_file_path)
             else:
-                upload_file_path = PurePosixPath(os.environ['NETWORK_LOCATION'], file_path[1:])
+                base_file_path = file_path[1:]
+                upload_file_path = PurePosixPath(os.environ['NETWORK_LOCATION'], base_file_path)
 
             s3_client.upload_file(upload_file_path, bucket, f'{asset_uuid}/{file_id}')
-            assets.append((file_id, upload_file_path.name if isinstance(upload_file_path, PurePath) else upload_file_path, asset_uuid))
+            assets.append((file_id, str(base_file_path), asset_uuid))
         json_bytes = io.BytesIO(json.dumps(all_metadata).encode("utf-8"))
         s3_client.upload_fileobj(json_bytes, bucket, f"{asset_uuid}.metadata")
         all_sqs_messages.append(json.dumps({'assetId': asset_uuid, 'bucket': bucket}))
@@ -215,7 +219,7 @@ def write_to_ic_db(assets, connection: sqlite3.Connection):
 
 if __name__ == "__main__":
     if len(sys.argv) > 1:
-        intelligent_caching_db_path = sys.argv[0]
+        intelligent_caching_db_path = sys.argv[1]
         migrate(intelligent_caching_db_path)
     else:
         raise Exception("Missing arg: Path to SQLite database.")


### PR DESCRIPTION
PurePath().name just returns the file name instead of the full path. We
also don't want the network location in there because this isn't
accounted for in the Preservica database.

I've changed the sys.argv because the first argument is the script name
because Python is fun.

I've added the SET TRANSACTION READ ONLY which will give us some minor
protection against accidentally updating the DRI database.
