### PR TITLE
DR2-2894 Department blank where it shouldn't be

### DIFF
--- a/scala/lambdas/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryService.scala
+++ b/scala/lambdas/ingest-mapper/src/main/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryService.scala
@@ -74,7 +74,7 @@ object DiscoveryService {
         Async[F].pure(DiscoveryCollectionAsset(citableReference, DiscoveryScopeContent(None), None))
 
       def getAssetFromDiscoveryApi(citableReference: String): F[DiscoveryCollectionAsset] = {
-        val uri = uri"$discoveryBaseUrl/API/records/v1/collection/$citableReference"
+        val uri = uri"$discoveryBaseUrl/API/records/v1/collection/$citableReference?source=TNA"
         val request = basicRequest.get(uri).response(asJson[DiscoveryCollectionAssetResponse])
         for {
           response <- backend.send(request)

--- a/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryServiceTest.scala
+++ b/scala/lambdas/ingest-mapper/src/test/scala/uk/gov/nationalarchives/ingestmapper/DiscoveryServiceTest.scala
@@ -79,9 +79,9 @@ class DiscoveryServiceTest extends AnyFlatSpec {
 
   "getAssetFromDiscoveryApi" should "return the correct values for series and department" in {
     val backend: WebSocketStreamBackendStub[IO, Fs2Streams[IO]] = WebSocketStreamBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
-      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T?source=TNA"))
       .thenRespond(bodyMap("T"))
-      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST?source=TNA"))
       .thenRespond(bodyMap("T TEST"))
 
     val departmentCollectionAsset = DiscoveryService(baseUrl, backend, uuidIterator)
@@ -126,9 +126,9 @@ class DiscoveryServiceTest extends AnyFlatSpec {
     val emptyResponse: Response[Exact] = ResponseStub(Exact("""{"assets": []}"""), StatusCode.Ok)
 
     val backend: WebSocketStreamBackendStub[IO, Fs2Streams[IO]] = WebSocketStreamBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
-      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T?source=TNA"))
       .thenRespond(emptyResponse)
-      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST?source=TNA"))
       .thenRespond(bodyMap("T TEST"))
 
     val departmentItem = DiscoveryService(baseUrl, backend, uuidIterator)
@@ -151,9 +151,9 @@ class DiscoveryServiceTest extends AnyFlatSpec {
     val emptyResponse: Response[Exact] = ResponseStub(Exact("""{"assets": []}"""), StatusCode.Ok)
 
     val backend: WebSocketStreamBackendStub[IO, Fs2Streams[IO]] = WebSocketStreamBackendStub[IO, Fs2Streams[IO]](new CatsMonadError())
-      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T?source=TNA"))
       .thenRespond(bodyMap("T"))
-      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST"))
+      .whenRequestMatches(_.uri.equals(uri"$baseUrl/API/records/v1/collection/T TEST?source=TNA"))
       .thenRespond(emptyResponse)
 
     val departmentItem = DiscoveryService(baseUrl, backend, uuidIterator)


### PR DESCRIPTION
For the series, discovery can return more than one asset if there
are assets there from other archives. These don't have the title in
the XML format we're expecting so the XML load fails.

We need to filter only TNA assets. This is done by added source=TNA
to the URL.
