### PR TITLE
Change flow control config.

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -675,6 +675,7 @@ resource "aws_ssm_parameter" "flow_control_config" {
     max_concurrency            = local.selected_flow_control_config.max_concurrency,
     tdr_reserved_channels      = local.selected_flow_control_config.tdr_reserved_channels,
     courtdoc_reserved_channels = local.selected_flow_control_config.courtdoc_reserved_channels
+    default_reserved_channels  = local.selected_flow_control_config.default_reserved_channels
   })
 }
 

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -110,16 +110,19 @@ locals {
       max_concurrency            = 3
       tdr_reserved_channels      = 1
       courtdoc_reserved_channels = 1
+      default_reserved_channels  = 1
     }
     prod = {
       max_concurrency            = 4
-      tdr_reserved_channels      = 2
+      tdr_reserved_channels      = 1
       courtdoc_reserved_channels = 2
+      default_reserved_channels  = 1
     }
     staging = {
       max_concurrency            = 3
-      tdr_reserved_channels      = 0
-      courtdoc_reserved_channels = 0
+      tdr_reserved_channels      = 1
+      courtdoc_reserved_channels = 1
+      default_reserved_channels  = 1
     }
   }
   selected_flow_control_config = local.flow_control_configs[local.environment]

--- a/terraform/templates/ssm/ingest_flow_control_config.json.tpl
+++ b/terraform/templates/ssm/ingest_flow_control_config.json.tpl
@@ -14,7 +14,7 @@
     },
     {
       "systemName": "DEFAULT",
-      "reservedChannels": 0,
+      "reservedChannels": ${default_reserved_channels},
       "probability": 20
     }
   ]


### PR DESCRIPTION
I put through a single DRI migration ingest and it got stuck on flow control.
It wasn't a TDR or a COURTDOC ingest so it didn't proceed because the default
system had no reserved channels.

This isn't a problem when running the e2e tests, I suspect because there are
other ingests which retrigger the flow control lambda and start it working.

I changed the config in prod to this and it worked.
