### PR TITLE
DR2-2897 Add additional metadata to json file.

### DIFF
--- a/python/dri-migration/create_ingest_metadata_test.py
+++ b/python/dri-migration/create_ingest_metadata_test.py
@@ -141,6 +141,7 @@ class TestMigrate(unittest.TestCase):
             self.assertEqual(unit_ref.replace("-", ""), metadata["IAID"])
             self.assertEqual("series1", metadata["Series"])
             self.assertEqual(checksum, metadata["checksum_sha256"])
+            self.assertEqual("meta", metadata["preservicaMetadata"])
             self.assertEqual(expected_digital_asset_source, metadata["digitalAssetSource"])
             self.assertEqual(1, metadata["sortOrder"])
             self.assertEqual("testenv-dr2-ingest-dri-migration-cache", bucket)

--- a/python/dri-migration/migrate/create_ingest_metadata.py
+++ b/python/dri-migration/migrate/create_ingest_metadata.py
@@ -136,7 +136,7 @@ def migrate(ic_db_path):
                 "TransferInitiatedDatetime": str(row[column_indexes["TRANSFERINITIATEDDATETIME"]]),
                 "Filename": row[column_indexes["FILENAME"]],
                 "FileReference": row[column_indexes["FILEREFERENCE"]],
-                "metadata": str(row[column_indexes["METADATA"]]),
+                "preservicaMetadata": str(row[column_indexes["METADATA"]]),
                 "ClientSideOriginalFilepath": file_path,
                 "digitalAssetSource": security_tag,
                 "sortOrder": sort_order,

--- a/python/lambdas/preingest-importer/README.md
+++ b/python/lambdas/preingest-importer/README.md
@@ -35,17 +35,25 @@ The lambda doesn't return anything, but it sends a message to `OUTPUT_QUEUE_URL`
     3. Confirm that UUID is in the correct format
     4. Confirm that Series exists
     5. Confirm that Series is in the correct format
-5. Copy files from the `bucket` to the `OUTPUT_BUCKET_NAME`
-6. If `DELETE_FROM_SOURCE` is set to `true`, delete all files and metadata json from the source bucket.
-7. Send the `assetId`, location of the metadata file and `messageId` (if there is one) to `OUTPUT_QUEUE_URL`
+5. If the `RECORDS_METADATA_BUCKET` environment variable is set, then
+    1. Loop through the objects in the JSON metadata.
+    2. For each object, create an object key which is `live/{series}/{file_reference}` with any `/` in the file
+       reference replaced by `-`.
+    3. Load this JSON file from the bucket referenced by `RECORDS_METADATA_BUCKET`.
+    4. Add this to a `migratedMetadata` field in the original JSON.
+    5. Upload this new JSON back to the source bucket.
+6. Copy files from the `bucket` to the `OUTPUT_BUCKET_NAME`
+7. If `DELETE_FROM_SOURCE` is set to `true`, delete all files and metadata json from the source bucket.
+8. Send the `assetId`, location of the metadata file and `messageId` (if there is one) to `OUTPUT_QUEUE_URL`
 
 [Link to the infrastructure code](https://github.com/nationalarchives/dp-terraform-environments)
 
 ## Environment Variables
 
-| Name               | Description                                                                                                                   |
-|--------------------|-------------------------------------------------------------------------------------------------------------------------------|
-| OUTPUT_BUCKET_NAME | The DR2 bucket to copy the files to                                                                                           |
-| OUTPUT_QUEUE_URL   | The SQS queue to send the non-metadata file locations to                                                                      |
-| DELETE_FROM_SOURCE | An optional variable. If set to 'true', the lambda will delete all files and metadata from the source bucket                  |
-| SKIP_VALIDATION    | An optional variable. If set to 'true', the lambda will not validate the metadata. This is used when the metadata is not JSON |
+| Name                    | Description                                                                                                                   |
+|-------------------------|-------------------------------------------------------------------------------------------------------------------------------|
+| OUTPUT_BUCKET_NAME      | The DR2 bucket to copy the files to                                                                                           |
+| OUTPUT_QUEUE_URL        | The SQS queue to send the non-metadata file locations to                                                                      |
+| DELETE_FROM_SOURCE      | An optional variable. If set to 'true', the lambda will delete all files and metadata from the source bucket                  |
+| SKIP_VALIDATION         | An optional variable. If set to 'true', the lambda will not validate the metadata. This is used when the metadata is not JSON |
+| RECORDS_METADATA_BUCKET | An optional variable. If set, load the migrated DRI metadata from this bucket and add it to the metadata JSON file            |

--- a/python/lambdas/preingest-importer/lambda_function.py
+++ b/python/lambdas/preingest-importer/lambda_function.py
@@ -1,3 +1,4 @@
+import io
 import itertools
 import json
 import os
@@ -18,6 +19,7 @@ def lambda_handler(event, context):
     destination_queue = os.environ["OUTPUT_QUEUE_URL"]
     delete_from_source = os.getenv("DELETE_FROM_SOURCE", "false") == "true"
     skip_validation = os.getenv("SKIP_VALIDATION", "false") == "true"
+    records_metadata_bucket = os.getenv("RECORDS_METADATA_BUCKET")
     for record in event["Records"]:
         body: dict[str, str] = json.loads(record["body"])
         asset_id = body["assetId"] if "assetId" in body else body["fileId"]
@@ -26,7 +28,10 @@ def lambda_handler(event, context):
         try:
             file_objects = assert_objects_exist_in_bucket(source_bucket, asset_id)
             if not skip_validation:
-                validate_metadata(source_bucket, metadata_file_id)
+                json_metadata = validate_metadata(source_bucket, metadata_file_id)
+                if records_metadata_bucket:
+                    copy_records_metadata(source_bucket, records_metadata_bucket, json_metadata, metadata_file_id)
+
             transfer_files = [f['Key'] for f in file_objects]
             copy_objects(destination_bucket, transfer_files, source_bucket)
             potential_message_id = {key: value for key, value in body.items() if key == "messageId"}
@@ -40,6 +45,19 @@ def lambda_handler(event, context):
         except Exception as e:
             print(json.dumps({"error": str(e), "assetId": asset_id}))
             raise Exception(e)
+
+
+def copy_records_metadata(source_bucket, records_metadata_bucket, json_metadata, metadata_file_key):
+    for metadata in json_metadata:
+        series = metadata["Series"]
+        file_reference = metadata["FileReference"].replace("/", "-")
+        key = f"live/{series}-{file_reference}.json"
+        response = s3_client.get_object(Bucket=records_metadata_bucket, Key=key)
+        migrated_metadata = json.loads(response['Body'].read().decode('utf-8'))
+        metadata["migratedMetadata"] = migrated_metadata
+    json_bytes = io.BytesIO(json.dumps([json_metadata]).encode("utf-8"))
+    s3_client.upload_fileobj(json_bytes, source_bucket, metadata_file_key)
+
 
 
 def list_all_objects(source_bucket, file_id):
@@ -74,6 +92,7 @@ def validate_metadata(bucket, s3_key):
     for metadata in json_metadata:
         validate_mandatory_fields_exist(f"common/preingest-{source_system}/metadata-schema.json", metadata)
         validate_formats(metadata, bucket, s3_key)
+    return json_metadata
 
 
 def validate_mandatory_fields_exist(schema_location, json_metadata):

--- a/python/lambdas/preingest-importer/lambda_function_test.py
+++ b/python/lambdas/preingest-importer/lambda_function_test.py
@@ -1,3 +1,4 @@
+import io
 import json
 import os
 import unittest
@@ -73,6 +74,65 @@ class TestLambdaFunction(unittest.TestCase):
                   mock_get_object, mock_send_message, mock_copy, mock_head_object, mock_list_objects):
         copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object, mock_delete_object,
                     mock_send_message, mock_copy, mock_head_object, mock_list_objects, skip_validation=True)
+
+    @patch('lambda_function.s3_client.list_objects')
+    @patch('lambda_function.s3_client.head_object')
+    @patch('lambda_function.copy_objects')
+    @patch('lambda_function.sqs_client.send_message')
+    @patch('lambda_function.s3_client.get_object')
+    @patch('lambda_function.copy_records_metadata')
+    @patch('lambda_function.validate_mandatory_fields_exist')
+    @patch('lambda_function.validate_formats')
+    @patch.dict(os.environ, {'OUTPUT_BUCKET_NAME': 'destination-bucket'})
+    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
+    @patch.dict(os.environ, {'RECORDS_METADATA_BUCKET': 'records-metadata-bucket'})
+    def test_copy_calls_copy_records_metadata_when_records_metadata_bucket_set(
+            self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_copy_records_metadata,
+            mock_get_object, mock_send_message, mock_copy, mock_head_object, mock_list_objects):
+        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
+        key = f'{asset_id}/{file_id}'
+        contents = [{'Size': 1024, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
+        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
+        mock_head_object.return_value = {'ContentLength': 1024}
+        mock_validate_mandatory_fields_exist.return_value = True
+        mock_validate_formats.return_value = True
+        metadata_object = {
+            "ConsignmentReference": "TDR-2024-PQXN",
+            "FileReference": "ZDSCFC",
+            "Series": "SMTH 123",
+            "TransferInitiatedDatetime": "2024-09-19 07:21:57",
+            "UUID": "0000c951-b332-4d45-93e7-8c24eec4b1f1"
+        }
+        mock_get_object.return_value = {
+            'Body': io.BytesIO(b'[' + json.dumps(metadata_object).encode() + b']')
+        }
+        event = {'Records': [{'body': json.dumps({"bucket": "source-bucket", "assetId": asset_id})}]}
+        context = {}
+
+        lambda_function.lambda_handler(event, context)
+
+        mock_copy_records_metadata.assert_called_once_with(
+            'source-bucket', 'records-metadata-bucket', [metadata_object], f'{asset_id}.metadata')
+
+    def test_copy_records_metadata_uploads_merged_metadata(self):
+        with patch('lambda_function.s3_client.get_object') as mock_get_object, \
+                patch('lambda_function.s3_client.upload_fileobj') as mock_upload_fileobj:
+            migrated_metadata = {"foo": "bar"}
+            mock_get_object.return_value = {'Body': io.BytesIO(json.dumps(migrated_metadata).encode('utf-8'))}
+            json_metadata = [{"Series": "MOCK1 123", "FileReference": "AB/12"}]
+
+            lambda_function.copy_records_metadata('source-bucket', 'records-metadata-bucket', json_metadata,
+                                                   'asset-id.metadata')
+
+            mock_get_object.assert_called_once_with(Bucket='records-metadata-bucket', Key='live/MOCK1 123-AB-12.json')
+            self.assertEqual(migrated_metadata, json_metadata[0]['migratedMetadata'])
+
+            mock_upload_fileobj.assert_called_once()
+            call_args = mock_upload_fileobj.call_args.args
+            self.assertEqual('source-bucket', call_args[1])
+            self.assertEqual('asset-id.metadata', call_args[2])
+            uploaded_content = json.loads(call_args[0].getvalue().decode('utf-8'))
+            self.assertEqual([json_metadata], uploaded_content)
 
     @patch('lambda_function.s3_client.list_objects')
     @patch('lambda_function.s3_client.head_object')

--- a/terraform/preingest.tf
+++ b/terraform/preingest.tf
@@ -41,6 +41,13 @@ module "dri_preingest" {
   lambda_code_version                          = var.lambda_code_version
   notifications_topic_arn                      = module.dr2_notifications_sns.sns_arn
   code_deploy_bucket                           = "mgmt-dp-code-deploy"
+  additional_importer_lambda_policies = local.environment == "prod" ? {
+    "${local.environment}-copy-from-records-metadata" = templatefile("${path.module}/templates/iam_policy/preingest_dri_records_metadata.json.tpl", {
+      records_metadata_bucket = local.records_metadata_bucket_name
+      source_bucket           = local.dri_migration_bucket_name
+    })
+  } : {}
+  additional_importer_lambda_env_vars = local.environment == "prod" ? { RECORDS_METADATA_BUCKET = local.records_metadata_bucket_name } : {}
 }
 
 module "ad_hoc_preingest" {

--- a/terraform/records_metadata.tf
+++ b/terraform/records_metadata.tf
@@ -8,7 +8,8 @@ module "dr2_records_metadata_key" {
     ci_roles = [local.terraform_role_arn],
     user_roles = [
       data.aws_iam_role.org_wiz_access_role.arn,
-      data.aws_ssm_parameter.dev_admin_role.value
+      data.aws_ssm_parameter.dev_admin_role.value,
+      module.dri_preingest.importer_lambda.role
     ]
   }
 }

--- a/terraform/templates/iam_policy/preingest_dri_records_metadata.json.tpl
+++ b/terraform/templates/iam_policy/preingest_dri_records_metadata.json.tpl
@@ -1,0 +1,26 @@
+{
+  "Statement": [
+    {
+      "Action": [
+        "s3:ListBucket",
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${records_metadata_bucket}",
+        "arn:aws:s3:::${records_metadata_bucket}/*"
+      ]
+    },
+    {
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+        "arn:aws:s3:::${source_bucket}",
+        "arn:aws:s3:::${source_bucket}/*"
+      ]
+    }
+  ],
+  "Version": "2012-10-17"
+}


### PR DESCRIPTION
* Rename `metadata` to `preservicaMetadata` in the DRI migration script. Calling it preservica is fine because it references old Preservica. We're going to delete the existing RG40 and 140 ingests and re-import so there's no need to update existing metadata
* Change the importer code to load the dri metadata and add it to the json file.
* Add an environment variable with the bucket name only for the DRI importer.
* Add extra permissions to allow the lambda to do this.
* Update the tests.
