### PR TITLE
DDSM-558 Version bump for AWS clients.

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,7 +2,7 @@ import sbt._
 object Dependencies {
   lazy val logbackVersion = "2.26.0"
   lazy val pureConfigVersion = "0.17.10"
-  lazy val daAwsClientsVersion = "0.1.158"
+  lazy val daAwsClientsVersion = "0.1.160"
   private val fs2Version = "3.13.0"
   private val sttpVersion = "4.0.25"
   private val circeVersion = "0.15.0-M1"


### PR DESCRIPTION
I've bumped the version of the aws sdk in da-aws-clients to include the fix for
https://github.com/aws/aws-sdk-java-v2/issues/7117

This will deploy that to the ingest lambdas
