### PR TITLE
DR2-2903 Update Ids.

### DIFF
--- a/scala/lambdas/preingest-tdr-package-builder/README.md
+++ b/scala/lambdas/preingest-tdr-package-builder/README.md
@@ -19,9 +19,10 @@ Because of aggregation, assets are grouped and therefore each have group ID in t
    1. get the url from the `location` field and use it to download the metadata file (from S3)
       *  an example of some of the fields a `<uuid>.metadata` file might contain
            ```json
-           {
+           [{
               "Series":"TEST 123",
               "UUID":"0000b033-a309-4c42-8397-ba7854e345e2",
+              "AssetId": "571bbd56-e823-4e8e-859a-d08002d33c75",
               "description":null,
               "TransferringBody":"TestBody",
               "TransferInitiatedDatetime":"2024-10-07 09:54:48",
@@ -30,7 +31,7 @@ Because of aggregation, assets are grouped and therefore each have group ID in t
               "SHA256ServerSideChecksum":"33e806a1d38ec24fec78fd41f5ea3f54a300f9e1652e6d0b0b1eeca8e25d27ed",
               "FileReference":"Z1BA8C",
               "ClientSideOriginalFilepath":"/path/to/file"
-           }
+           }]
            ```
    2. convert the byte array returned into a string
    3. decode this string into a list of `PackageMetadata` objects
@@ -38,7 +39,7 @@ Because of aggregation, assets are grouped and therefore each have group ID in t
       1. generate:
          1. a `FileMetadataObject` with information on the file
             * file size and S3 key is obtained from the file in S3
-         2. an `AssetMetadataObject` (its parent)
+         2. an `AssetMetadataObject` (its parent). The ID for this object is found by checking for `AssetId` in the JSON. If this is not there then `UUID` is used.
          3. a `ContentFolderObject` (the Asset's parent), if the ContentFolder isn't already in the ContentFolder cache
             and then update the cache with the newly created object
       2. generate a `FileMetadataObject` with information on the `<uuid>.metadata` metadata file (in S3)

--- a/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
@@ -120,12 +120,13 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
         firstPackageMetadata <- IO.fromOption(packageMetadataList.headOption)(new Exception("The metadata list is empty"))
       } yield {
         val metadataFileSize = metadataArr.length
+        val potentialAssetId = firstPackageMetadata.assetId.orElse(firstPackageMetadata.UUID)
         FileMetadataObject(
           metadataId,
-          Option(firstPackageMetadata.UUID),
-          s"${firstPackageMetadata.UUID}-metadata",
+          potentialAssetId,
+          s"${potentialAssetId.get}-metadata",
           packageMetadataList.flatMap(_.sortOrder).maxOption.getOrElse(packageMetadataList.length + 1),
-          s"${firstPackageMetadata.UUID}-metadata.json",
+          s"${potentialAssetId.get}-metadata.json",
           metadataFileSize,
           Preservation,
           1,
@@ -204,7 +205,7 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
         metadataId: UUID,
         potentialMessageId: Option[String]
     ): IO[AssetMetadataObject] = IO.pure {
-      val assetId = packageMetadata.UUID
+      val assetId = packageMetadata.assetId.getOrElse(packageMetadata.UUID.get)
       val sourceSpecificIdentifiers = config.sourceSystem match {
         case SourceSystem.TDR => List(IdField("BornDigitalRef", packageMetadata.fileReference), IdField(upstreamSystemRefIdKey, packageMetadata.fileReference))
         case SourceSystem.DRI =>
@@ -279,7 +280,8 @@ object Lambda:
   given Decoder[PackageMetadata] = (c: HCursor) =>
     for
       series <- c.downField("Series").as[String]
-      uuid <- c.downField("UUID").as[UUID]
+      uuid <- c.downField("UUID").as[Option[UUID]]
+      assetId <- c.downField("AssetId").as[Option[UUID]]
       fileId <- c.downField("fileId").as[UUID]
       description <- c.downField("description").as[Option[String]]
       transferringBody <- c.downField("TransferringBody").as[Option[String]]
@@ -298,6 +300,7 @@ object Lambda:
     yield PackageMetadata(
       series,
       uuid,
+      assetId,
       fileId,
       description,
       transferringBody,
@@ -317,7 +320,8 @@ object Lambda:
 
   case class PackageMetadata(
       series: String,
-      UUID: UUID,
+      UUID: Option[UUID],
+      assetId: Option[UUID],
       fileId: UUID,
       description: Option[String],
       transferringBody: Option[String],

--- a/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
@@ -33,6 +33,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
 
   case class TestData(
       fileId: UUID,
+      assetId: Option[UUID],
       series: String,
       body: Option[String],
       date: Option[String],
@@ -73,7 +74,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     suffix <- Gen.asciiStr
   } yield FileName(prefix, suffix)
 
-  val fileNameGen = Gen.oneOf(numericFileNameGen, stringFileNameGen)
+  val fileNameGen: Gen[FileName] = Gen.oneOf(numericFileNameGen, stringFileNameGen)
 
   val nonZeroDigit: Gen[Int] = Gen.choose(1, 9)
 
@@ -100,6 +101,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
 
   val testDataGen: Gen[TestData] = for {
     series <- Gen.asciiStr
+    assetId <- Gen.option(Gen.uuid)
     body <- Gen.option(Gen.asciiStr)
     fileId <- Gen.uuid
     date <- Gen.option(dateGen)
@@ -120,6 +122,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     upstreamSystem <- Gen.oneOf(SourceSystem.values.toList)
   } yield TestData(
     fileId,
+    assetId,
     series,
     body,
     date,
@@ -161,7 +164,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     val uuidIterator: () => UUID = () => uuids.next()
     def createPackageMetadata(testData: TestData) = PackageMetadata(
       testData.series,
-      tdrFileId,
+      if testData.assetId.isDefined then None else Option(tdrFileId),
+      testData.assetId,
       testData.fileId,
       testData.description,
       testData.body,
@@ -191,11 +195,13 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
       .to(string)
       .unsafeRunSync()
 
+    val expectedId = if testData.assetId.isDefined then testData.assetId.get else tdrFileId
+
     val potentialLockTableMessageId = Some("messageId")
-    val initialS3Objects = allTestData.map(testData => s"$tdrFileId/${testData.fileId}" -> MockTdrFile(testData.fileSize)).toMap ++ Map(s"$tdrFileId.metadata" -> packageMetadata)
+    val initialS3Objects = allTestData.map(testData => s"$expectedId/${testData.fileId}" -> MockTdrFile(testData.fileSize)).toMap ++ Map(s"$expectedId.metadata" -> packageMetadata)
 
     val initialDynamoObjects = allTestData.map { testData =>
-      val lockTableMessageAsString = new LockTableMessage(UUID.randomUUID(), URI.create(s"s3://bucket/$tdrFileId.metadata"), potentialLockTableMessageId).asJson.noSpaces
+      val lockTableMessageAsString = new LockTableMessage(UUID.randomUUID(), URI.create(s"s3://bucket/$expectedId.metadata"), potentialLockTableMessageId).asJson.noSpaces
       IngestLockTableItem(UUID.randomUUID(), testData.groupId, lockTableMessageAsString, dateTimeNow.toString)
     }
     val input = Input(testData.groupId, testData.batchId, 1, 2)
@@ -226,10 +232,10 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     contentFolderMetadataObject.parentId should equal(None)
     contentFolderMetadataObject.series should equal(Option(testData.series))
 
-    assetMetadataObject.id should equal(tdrFileId)
+    assetMetadataObject.id should equal(expectedId)
     assetMetadataObject.parentId should equal(Option(uuidList(1)))
     assetMetadataObject.title should equal(expectedTitle)
-    assetMetadataObject.name should equal(tdrFileId.toString)
+    assetMetadataObject.name should equal(expectedId.toString)
     assetMetadataObject.originalMetadataFiles should equal(List(uuidList.head))
     assetMetadataObject.description should equal(testData.description)
     assetMetadataObject.transferringBody should equal(testData.body)
@@ -259,7 +265,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
 
     if testData.upstreamSystem == SourceSystem.TDR then checkIdField("BornDigitalRef", testData.fileRef)
     testData.tdrRef.foreach(tdrRef => checkIdField("ConsignmentReference", tdrRef))
-    checkIdField("RecordID", tdrFileId.toString)
+    checkIdField("RecordID", expectedId.toString)
 
     if List(SourceSystem.ADHOC, SourceSystem.PA, SourceSystem.DRI).contains(testData.upstreamSystem) && testData.iaid.isDefined then
       checkIdField("DiscoveryIAID", testData.iaid.get)
@@ -270,26 +276,26 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
       val potentialFileObject = fileObjects.find(_.id == testData.fileId)
       potentialFileObject.isDefined should equal(true)
       val fileObject = potentialFileObject.get
-      fileObject.parentId should equal(Option(tdrFileId))
+      fileObject.parentId should equal(Option(expectedId))
       fileObject.title should equal(testData.fileName.fileString)
       fileObject.sortOrder should equal(testData.sortOrder.getOrElse(idx + 1))
       fileObject.name should equal(testData.fileName.fileString)
       fileObject.fileSize should equal(testData.fileSize)
       fileObject.representationType should equal(RepresentationType.Preservation)
       fileObject.representationSuffix should equal(1)
-      fileObject.location should equal(URI.create(s"s3://bucket/$tdrFileId/${testData.fileId}"))
+      fileObject.location should equal(URI.create(s"s3://bucket/$expectedId/${testData.fileId}"))
       fileObject.checksums should equal(testData.checksums)
     }
 
     val metadataSortOrder = allTestData.flatMap(_.sortOrder).maxOption.getOrElse(fileObjects.size + 1)
-    metadataFileMetadataObject.parentId should equal(Option(tdrFileId))
-    metadataFileMetadataObject.title should equal(s"$tdrFileId-metadata")
+    metadataFileMetadataObject.parentId should equal(Option(expectedId))
+    metadataFileMetadataObject.title should equal(s"$expectedId-metadata")
     metadataFileMetadataObject.sortOrder should equal(metadataSortOrder)
-    metadataFileMetadataObject.name should equal(s"$tdrFileId-metadata.json")
+    metadataFileMetadataObject.name should equal(s"$expectedId-metadata.json")
     metadataFileMetadataObject.fileSize should equal(packageMetadata.getBytes.length)
     metadataFileMetadataObject.representationType should equal(RepresentationType.Preservation)
     metadataFileMetadataObject.representationSuffix should equal(1)
-    metadataFileMetadataObject.location should equal(URI.create(s"s3://bucket/$tdrFileId.metadata"))
+    metadataFileMetadataObject.location should equal(URI.create(s"s3://bucket/$expectedId.metadata"))
     metadataFileMetadataObject.checksums.head should equal(Checksum("sha256", metadataChecksum))
 
     output.groupId should equal(testData.groupId)
@@ -308,7 +314,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     val uuidIterator: () => UUID = () => UUID.randomUUID
     def packageMetadata(consignmentReference: String, fileId: UUID) = PackageMetadata(
       "TST 123",
-      tdrAssetId,
+      None,
+      Option(tdrAssetId),
       fileId,
       None,
       Option("body"),
@@ -387,7 +394,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
       List(
         PackageMetadata(
           "",
-          assetId,
+          Option(assetId),
+          None,
           fileId,
           None,
           Option(""),
@@ -419,7 +427,28 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     val initialDynamoObjects = List(IngestLockTableItem(UUID.randomUUID(), "TST-123", lockTableMessageAsString, dateTimeNow.toString))
 
     val packageMetadata =
-      List(PackageMetadata("", assetId, fileId, None, Option(""), Option("2024-10-04 10:00:00"), None, "test.txt", checksum(""), "", "", None, None, None, None, None, None))
+      List(
+        PackageMetadata(
+          "",
+          Option(assetId),
+          None,
+          fileId,
+          None,
+          Option(""),
+          Option("2024-10-04 10:00:00"),
+          None,
+          "test.txt",
+          checksum(""),
+          "",
+          "",
+          None,
+          None,
+          None,
+          None,
+          None,
+          None
+        )
+      )
     val initialS3Objects = Map(s"$assetId.metadata" -> packageMetadata.asJson.noSpaces, s"$assetId/$fileId" -> MockTdrFile(1))
     val adhocConfig: Config = Config("", "", "cacheBucket", 1, ADHOC)
     val (s3Contents, output) = runHandler(initialS3Objects = initialS3Objects, initialDynamoObjects = initialDynamoObjects, config = adhocConfig)
@@ -438,7 +467,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     val packageMetadata = List(
       PackageMetadata(
         "",
-        assetId,
+        Option(assetId),
+        None,
         fileId,
         None,
         Option(""),
@@ -478,7 +508,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
       List(
         PackageMetadata(
           "",
-          assetId,
+          None,
+          Option(assetId),
           fileId,
           None,
           Option(""),
@@ -511,7 +542,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
   "lambda handler" should "attach the asset to the correct content folder for pa transfers if there are multiple series" in {
     def packageMetadata(series: String) = PackageMetadata(
       series,
-      UUID.randomUUID,
+      Option(UUID.randomUUID),
+      None,
       UUID.randomUUID,
       None,
       Option(""),
@@ -552,7 +584,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     val contentIdToName = metadataList.collect { case c: ContentFolderMetadataObject => c.id -> c.series.get }.toMap
 
     def checkAssetParent(packageMetadata: PackageMetadata, expectedName: String) = {
-      val assetParent = assetNameToParent(packageMetadata.UUID.toString)
+      val assetParent = assetNameToParent(packageMetadata.UUID.get.toString)
       contentIdToName(assetParent) should equal(expectedName)
     }
 

--- a/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/TestUtils.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/TestUtils.scala
@@ -32,7 +32,8 @@ object TestUtils:
     }
     val metadataObjectFields = List(
       ("Series", Json.fromString(m.series)).some,
-      ("UUID", Json.fromString(m.UUID.toString)).some,
+      m.UUID.map(u => "UUID" -> Json.fromString(u.toString)),
+      m.assetId.map(a => "AssetId" -> Json.fromString(a.toString)),
       ("fileId", Json.fromString(m.fileId.toString)).some,
       m.description.map(d => ("description", Json.fromString(d))),
       m.transferringBody.map(t => ("TransferringBody", Json.fromString(t))),


### PR DESCRIPTION
TDR have added an AssetId field although not all transfers will have it just yet.
At some point in the future they will stop using the UUID field.
So both of these need to be optional so TDR can change things without breaking our package builder.
