### PR TITLE
DR2-2898 Log ids before upload

### DIFF
--- a/scala/lambdas/preingest-courtdoc-importer/src/main/scala/uk/gov/nationalarchives/preingestcourtdocimporter/Lambda.scala
+++ b/scala/lambdas/preingest-courtdoc-importer/src/main/scala/uk/gov/nationalarchives/preingestcourtdocimporter/Lambda.scala
@@ -65,7 +65,10 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies]:
                     Stream
                       .emit[IO, ByteBuffer](ByteBuffer.wrap(byteArray))
                       .toPublisherResource
-                      .use(pub => dependencies.s3.upload(config.outputBucket, id.toString, FlowAdapters.toPublisher(pub)))
+                      .use { pub =>
+                        log(Map("bucket" -> config.outputBucket, "key" -> id.toString))("Uploading file to S3") >>
+                          dependencies.s3.upload(config.outputBucket, id.toString, FlowAdapters.toPublisher(pub))
+                      }
                       .map { _ =>
                         tarEntry.getName -> id
                       }


### PR DESCRIPTION
We are geting files left behind when the judgments are too large and the lambda runs out of memory.

I think this is because some are being copied over before they time out. We can't tell what they are at the moment
because the key we upload them to the raw cache bucket with is a random uuid.

This will log it as they're uploaded so if we get another OOM error in the courtdoc package builder, we can see which files it has copied over and
delete them manually.
