### PR TITLE
Migration fixes.

### DIFF
--- a/python/dri-migration/create_ingest_metadata_test.py
+++ b/python/dri-migration/create_ingest_metadata_test.py
@@ -121,8 +121,8 @@ class TestMigrate(unittest.TestCase):
 
         self.assertEqual([
             call("ingest_query.sql"),
-            call(call_paths[0]),
-            call(call_paths[1]),
+            call(call_paths[0], "rb"),
+            call(call_paths[1], "rb"),
         ], mock_open_file.call_args_list)
 
         calls = [
@@ -312,7 +312,6 @@ class TestMigrate(unittest.TestCase):
         sts_args = mock_sts_client.assume_role.call_args_list[0][1]
         self.assertEqual('arn:aws:iam::12345:role/test-dr2-ingest-dri-migration-role', sts_args['RoleArn'])
         self.assertEqual('dri-migration', sts_args['RoleSessionName'])
-        self.assertEqual(60 * 60 * 12, sts_args['DurationSeconds'])
 
         check_client(s3_client)
         check_client(sqs_client)

--- a/python/dri-migration/migrate/create_ingest_metadata.py
+++ b/python/dri-migration/migrate/create_ingest_metadata.py
@@ -47,8 +47,7 @@ sts_client = boto3.client("sts")
 def get_clients(account_number, environment):
     credentials = sts_client.assume_role(
         RoleArn=f"arn:aws:iam::{account_number}:role/{environment}-dr2-ingest-dri-migration-role",
-        RoleSessionName="dri-migration",
-        DurationSeconds=60 * 60 * 12
+        RoleSessionName="dri-migration"
     )['Credentials']
     access_key = credentials['AccessKeyId']
     secret_key = credentials['SecretAccessKey']

--- a/python/dri-migration/migrate/create_ingest_metadata.py
+++ b/python/dri-migration/migrate/create_ingest_metadata.py
@@ -190,11 +190,11 @@ def migrate(ic_db_path):
                 base_file_path = file_path[1:]
                 upload_file_path = PurePosixPath(os.environ['NETWORK_LOCATION'], base_file_path)
 
-            with open(upload_file_path) as upload_file:
+            with open(upload_file_path, "rb") as upload_file:
                 prefix = f"v1/{asset_uuid}"
                 tags = parse.urlencode([("Series", metadata["Series"])],)
                 s3_client.put_object(
-                    Body=upload_file.read(),
+                    Body=upload_file,
                     Key=f"{prefix}/{file_id}",
                     Bucket=object_store_bucket,
                     Tagging=tags,

--- a/python/dri-migration/migrate/create_ingest_metadata.py
+++ b/python/dri-migration/migrate/create_ingest_metadata.py
@@ -195,7 +195,7 @@ def migrate(ic_db_path):
                 prefix = f"v1/{asset_uuid}"
                 tags = parse.urlencode([("Series", metadata["Series"])],)
                 s3_client.put_object(
-                    Body=upload_file,
+                    Body=upload_file.read(),
                     Key=f"{prefix}/{file_id}",
                     Bucket=object_store_bucket,
                     Tagging=tags,

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -251,6 +251,7 @@ module "vpc" {
     preservica_ingest_bucket = local.preservica_ingest_bucket
     tdr_export_bucket        = local.tdr_export_bucket
     tre_export_bucket_arn    = local.tre_terraform_prod_config["s3_court_document_pack_out_arn"]
+    object_store_bucket_name = local.object_store_bucket_name
   })
   dynamo_gateway_endpoint_policy = templatefile("${path.module}/templates/vpc/dynamo_endpoint_policy.json.tpl", {
     account_id = data.aws_caller_identity.current.account_id

--- a/terraform/templates/iam_policy/dri_migration_policy.json.tpl
+++ b/terraform/templates/iam_policy/dri_migration_policy.json.tpl
@@ -30,7 +30,8 @@
     },
     {
       "Action": [
-        "kms:GenerateDataKey"
+        "kms:GenerateDataKey",
+	"kms:Decrypt"
       ],
       "Effect": "Allow",
       "Resource": "*",

--- a/terraform/templates/iam_policy/dri_migration_policy.json.tpl
+++ b/terraform/templates/iam_policy/dri_migration_policy.json.tpl
@@ -27,6 +27,18 @@
         "arn:aws:s3:::${object_store_bucket_name}",
         "arn:aws:s3:::${object_store_bucket_name}/*"
       ]
+    },
+    {
+      "Action": [
+        "kms:GenerateDataKey"
+      ],
+      "Effect": "Allow",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:PrincipalOrgID": "$${aws:ResourceOrgID}"
+        }
+      }
     }
   ]
 }

--- a/terraform/templates/iam_policy/dri_migration_policy.json.tpl
+++ b/terraform/templates/iam_policy/dri_migration_policy.json.tpl
@@ -31,7 +31,7 @@
     {
       "Action": [
         "kms:GenerateDataKey",
-	"kms:Decrypt"
+	    "kms:Decrypt"
       ],
       "Effect": "Allow",
       "Resource": "*",

--- a/terraform/templates/iam_policy/preingest_dri_records_metadata.json.tpl
+++ b/terraform/templates/iam_policy/preingest_dri_records_metadata.json.tpl
@@ -25,6 +25,13 @@
     },
     {
       "Action": [
+        "kms:Decrypt"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    },
+    {
+      "Action": [
         "s3:PutObject"
       ],
       "Effect": "Allow",

--- a/terraform/templates/vpc/s3_endpoint_policy.json.tpl
+++ b/terraform/templates/vpc/s3_endpoint_policy.json.tpl
@@ -28,7 +28,9 @@
         "arn:aws:s3:::${tdr_export_bucket}",
         "arn:aws:s3:::${tdr_export_bucket}/*",
         "${tre_export_bucket_arn}",
-        "${tre_export_bucket_arn}/*"
+        "${tre_export_bucket_arn}/*",
+        "arn:aws:s3:::${object_store_bucket_name}",
+        "arn:aws:s3:::${object_store_bucket_name}/*"
       ]
     }
   ]


### PR DESCRIPTION
You need to call read on the file object and we need permission for the migration role to generate a data key.

The * in the permissions is ok because the key itself is restricted.
