### PR TITLE
DR2-2922 Stop listing objects in importer

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -28,8 +28,8 @@ object Dependencies {
   lazy val fs2Core = "co.fs2" %% "fs2-core" % fs2Version
   lazy val fs2IO = "co.fs2" %% "fs2-io" % fs2Version
   lazy val fs2Reactive = "co.fs2" %% "fs2-reactive-streams" % fs2Version
-  lazy val jacksonCore = "tools.jackson.core" % "jackson-core" % "3.2.0"
-  lazy val jacksonDatabind = "tools.jackson.core" % "jackson-databind" % "3.1.4"
+  lazy val jacksonCore = "tools.jackson.core" % "jackson-core" % "3.2.1"
+  lazy val jacksonDatabind = "tools.jackson.core" % "jackson-databind" % "3.2.1"
   lazy val jawnFs2 = "org.typelevel" %% "jawn-fs2" % "2.6.0"
   lazy val jawnParser = "org.typelevel" %% "jawn-parser" % "1.7.0"
   lazy val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.1"

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -5,11 +5,12 @@ object Dependencies {
   lazy val daAwsClientsVersion = "0.1.160"
   private val fs2Version = "3.13.0"
   private val sttpVersion = "4.0.25"
-  private val circeVersion = "0.15.0-M1"
+  private val circeVersion = "0.14.16"
   private val log4CatsVersion = "2.8.0"
   private val awsLibraryVersion = "1.12.797"
   private lazy val scalaTestVersion = "3.2.20"
   private lazy val nettyVersion = "4.2.15.Final"
+  private lazy val jacksonVersion = "3.2.1"
 
   lazy val awsCrt = "software.amazon.awssdk.crt" % "aws-crt" % "0.47.2"
   lazy val awsLambda = "com.amazonaws" % "aws-java-sdk-lambda" % awsLibraryVersion
@@ -28,8 +29,8 @@ object Dependencies {
   lazy val fs2Core = "co.fs2" %% "fs2-core" % fs2Version
   lazy val fs2IO = "co.fs2" %% "fs2-io" % fs2Version
   lazy val fs2Reactive = "co.fs2" %% "fs2-reactive-streams" % fs2Version
-  lazy val jacksonCore = "tools.jackson.core" % "jackson-core" % "3.2.1"
-  lazy val jacksonDatabind = "tools.jackson.core" % "jackson-databind" % "3.2.1"
+  lazy val jacksonCore = "tools.jackson.core" % "jackson-core" % jacksonVersion
+  lazy val jacksonDatabind = "tools.jackson.core" % "jackson-databind" % jacksonVersion
   lazy val jawnFs2 = "org.typelevel" %% "jawn-fs2" % "2.6.0"
   lazy val jawnParser = "org.typelevel" %% "jawn-parser" % "1.7.0"
   lazy val jaxb = "javax.xml.bind" % "jaxb-api" % "2.3.1"

--- a/python/lambdas/preingest-importer/README.md
+++ b/python/lambdas/preingest-importer/README.md
@@ -26,22 +26,20 @@ The lambda doesn't return anything, but it sends a message to `OUTPUT_QUEUE_URL`
 1. Read the `assetId` (if it's there, else `fileId`) from the message body and save it as `assetId`
 2. Read the `bucket` and from the message body
 3. Determine the file S3 prefix which is the value of `filesPrefix` in the message body if present or `assetId` otherwise.
-4. Call `head_object` on the `s3://{bucket}/{prefix}` key (which contains all objects related to the asset), then:
-    1. Check if there are any file objects, if there aren't any, throw an exception
-    2. Return the files
-5. Call `get_object` to retrieve the metadata file using the url from `metadataLocation` in the message body.
+4. Call `get_object` to retrieve the metadata file using the url from `metadataLocation` in the message body.
     1. Convert metadata to a JSON
     2. Confirm that mandatory fields exist
     3. Confirm that UUID is in the correct format
     4. Confirm that Series exists
     5. Confirm that Series is in the correct format
-6. If the `RECORDS_METADATA_BUCKET` environment variable is set, then
+5. If the `RECORDS_METADATA_BUCKET` environment variable is set, then
     1. Loop through the objects in the JSON metadata.
     2. For each object, create an object key which is `live/{series}/{file_reference}` with any `/` in the file
        reference replaced by `-`.
     3. Load this JSON file from the bucket referenced by `RECORDS_METADATA_BUCKET`.
     4. Add this to a `migratedMetadata` field in the original JSON.
     5. Upload this new JSON back to the source bucket.
+6. Generate a list of keys by looping through the metadata JSON and concatenating the prefix from step 3 with the `fileId` from the JSON.
 7. Copy files from the `bucket` to the `OUTPUT_BUCKET_NAME`
 8. If `DELETE_FROM_SOURCE` is set to `true`, delete all files and metadata json from the source bucket.
 9. Send the `assetId`, location of the metadata file, files prefix and `messageId` (if there is one) to `OUTPUT_QUEUE_URL`

--- a/python/lambdas/preingest-importer/lambda_function.py
+++ b/python/lambdas/preingest-importer/lambda_function.py
@@ -6,9 +6,7 @@ import re
 import uuid
 
 import boto3
-import botocore
 import jsonschema
-from botocore.exceptions import ClientError
 from urllib import parse
 
 s3_client = boto3.client("s3")
@@ -29,14 +27,14 @@ def lambda_handler(event, context):
         metadata_source_bucket = parsed_metadata_url.netloc
         files_source_bucket = body["bucket"]
         files_prefix = body.get("filesPrefix", asset_id)
+        response = s3_client.get_object(Bucket=metadata_source_bucket, Key=metadata_file_id)
+        json_metadata = json.loads(response['Body'].read().decode('utf-8'))
         try:
-            file_objects = assert_objects_exist_in_bucket(files_source_bucket, files_prefix)
             if not skip_validation:
-                json_metadata = validate_metadata(metadata_source_bucket, metadata_file_id)
+                json_metadata = validate_metadata(json_metadata)
                 if records_metadata_bucket:
                     copy_records_metadata(metadata_source_bucket, records_metadata_bucket, json_metadata, metadata_file_id)
-
-            transfer_files = [f['Key'] for f in file_objects]
+            transfer_files = [f"{files_prefix}/{m['fileId']}" for m in json_metadata]
             copy_objects(destination_bucket, transfer_files, files_source_bucket)
             copy_objects(destination_bucket, [metadata_file_id], metadata_source_bucket)
             potential_message_id = {key: value for key, value in body.items() if key == "messageId"}
@@ -64,35 +62,12 @@ def copy_records_metadata(source_bucket, records_metadata_bucket, json_metadata,
     s3_client.upload_fileobj(json_bytes, source_bucket, metadata_file_key)
 
 
-
-def list_all_objects(source_bucket, file_id):
-    all_contents = []
-    is_truncated = True
-    while is_truncated:
-        response = s3_client.list_objects(Bucket=source_bucket, Prefix=file_id)
-        all_contents.extend(response['Contents'])
-        is_truncated = response['IsTruncated']
-
-    return all_contents
-
-
-def assert_objects_exist_in_bucket(source_bucket, asset_id):
-    try:
-        contents = list_all_objects(source_bucket, f"{asset_id.removesuffix("/")}/")
-        if not contents:
-            raise Exception(f"Asset '{asset_id}' has no files in '{source_bucket}'")
-        return contents
-    except botocore.exceptions.ClientError as ex:
-        raise Exception(f"Object '{asset_id}' does not exist in '{source_bucket}', underlying error is: '{ex}'")
-
-
-def validate_metadata(bucket, s3_key):
+def validate_metadata(json_metadata):
     source_system = os.environ["SOURCE_SYSTEM"]
-    response = s3_client.get_object(Bucket=bucket, Key=s3_key)
-    json_metadata = json.loads(response['Body'].read().decode('utf-8'))
+
     for metadata in json_metadata:
         validate_mandatory_fields_exist(f"common/preingest-{source_system}/metadata-schema.json", metadata)
-        validate_formats(metadata, bucket, s3_key)
+        validate_formats(metadata)
     return json_metadata
 
 
@@ -109,22 +84,22 @@ def validate_mandatory_fields_exist(schema_location, json_metadata):
     return True
 
 
-def validate_formats(json_metadata, bucket, s3_key):
+def validate_formats(json_metadata):
     uuid_content = json_metadata["UUID"]
     try:
         uuid.UUID(uuid_content)
     except ValueError:
         raise Exception(
-            f"Unable to parse UUID, '{uuid_content}' from file '{s3_key}' in bucket '{bucket}'. Invalid format")
+            f"Unable to parse UUID, '{uuid_content}' from file. Invalid format")
 
     series = json_metadata["Series"]
     if not series.strip():
-        raise Exception(f"Empty Series value in file '{s3_key}' in bucket '{bucket}'. Unable to proceed")
+        raise Exception("Empty Series value in file. Unable to proceed")
 
     pattern = "^([A-Z]{1,4} [1-9][0-9]{0,3}|Unknown|MOCK1 123)$"
     match = re.match(pattern, series)
     if not match:
-        raise Exception(f"Invalid Series value, '{series}' in file '{s3_key}' in bucket '{bucket}'. Unable to proceed")
+        raise Exception(f"Invalid Series value, '{series}' in file. Unable to proceed")
 
     return True
 
@@ -137,4 +112,3 @@ def copy_objects(destination_bucket, s3_keys, source_bucket):
         except Exception as e:
             print(f"Error during copy of '{s3_key}' from '{source_bucket}' to '{destination_bucket}': {e}")
             raise e
-

--- a/python/lambdas/preingest-importer/lambda_function.py
+++ b/python/lambdas/preingest-importer/lambda_function.py
@@ -31,7 +31,7 @@ def lambda_handler(event, context):
         json_metadata = json.loads(response['Body'].read().decode('utf-8'))
         try:
             if not skip_validation:
-                json_metadata = validate_metadata(json_metadata)
+                validate_metadata(json_metadata)
                 if records_metadata_bucket:
                     copy_records_metadata(metadata_source_bucket, records_metadata_bucket, json_metadata, metadata_file_id)
             transfer_files = [f"{files_prefix}/{m['fileId']}" for m in json_metadata]
@@ -68,7 +68,6 @@ def validate_metadata(json_metadata):
     for metadata in json_metadata:
         validate_mandatory_fields_exist(f"common/preingest-{source_system}/metadata-schema.json", metadata)
         validate_formats(metadata)
-    return json_metadata
 
 
 def validate_mandatory_fields_exist(schema_location, json_metadata):

--- a/python/lambdas/preingest-importer/lambda_function_test.py
+++ b/python/lambdas/preingest-importer/lambda_function_test.py
@@ -5,8 +5,6 @@ import unittest
 import uuid
 from unittest.mock import patch
 
-from botocore.exceptions import ClientError
-
 import lambda_function
 from test_utils import copy_helper
 
@@ -15,6 +13,7 @@ from test_utils import copy_helper
 @patch.dict('os.environ', {'OUTPUT_QUEUE_URL': 'destination-queue'})
 @patch.dict('os.environ', {'SOURCE_SYSTEM': 'dri'})
 class TestLambdaFunction(unittest.TestCase):
+
     @staticmethod
     def valid_metadata():
         return {
@@ -28,88 +27,115 @@ class TestLambdaFunction(unittest.TestCase):
             "SHA256ServerSideChecksum": "checksum"
         }
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
     @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
     @patch('lambda_function.s3_client.get_object')
     @patch('lambda_function.s3_client.delete_objects')
     @patch('lambda_function.validate_mandatory_fields_exist')
     @patch('lambda_function.validate_formats')
-    @patch.dict(os.environ, {'OUTPUT_BUCKET_NAME': 'destination-bucket'})
-    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
-    def test_copy(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_delete_object, mock_get_object,
-                  mock_send_message, mock_copy, mock_head_object, mock_list_objects):
-        copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object, mock_delete_object,
-                    mock_send_message, mock_copy, mock_head_object, mock_list_objects)
+    def test_copy(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_delete_object,
+            mock_get_object,
+            mock_send_message,
+            mock_copy):
+        copy_helper(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            mock_delete_object,
+            mock_send_message,
+            mock_copy)
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
     @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
     @patch('lambda_function.s3_client.get_object')
     @patch('lambda_function.s3_client.delete_objects')
     @patch('lambda_function.validate_mandatory_fields_exist')
     @patch('lambda_function.validate_formats')
-    @patch.dict(os.environ, {'OUTPUT_BUCKET_NAME': 'destination-bucket'})
-    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
     @patch.dict(os.environ, {'DELETE_FROM_SOURCE': 'true'})
-    def test_copy_with_source_delete(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_delete_object,
-                  mock_get_object, mock_send_message, mock_copy, mock_head_object, mock_list_objects):
-        copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object, mock_delete_object,
-                    mock_send_message, mock_copy, mock_head_object, mock_list_objects, should_delete=True)
+    def test_copy_with_source_delete(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_delete_object,
+            mock_get_object,
+            mock_send_message,
+            mock_copy):
+        copy_helper(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            mock_delete_object,
+            mock_send_message,
+            mock_copy,
+            should_delete=True)
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
     @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
     @patch('lambda_function.s3_client.get_object')
     @patch('lambda_function.s3_client.delete_objects')
     @patch('lambda_function.validate_mandatory_fields_exist')
     @patch('lambda_function.validate_formats')
-    @patch.dict(os.environ, {'OUTPUT_BUCKET_NAME': 'destination-bucket'})
-    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
     @patch.dict(os.environ, {'SKIP_VALIDATION': 'true'})
-    def test_copy_with_skip_validation(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_delete_object,
-                  mock_get_object, mock_send_message, mock_copy, mock_head_object, mock_list_objects):
-        copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object, mock_delete_object,
-                    mock_send_message, mock_copy, mock_head_object, mock_list_objects, skip_validation=True)
+    def test_copy_with_skip_validation(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_delete_object,
+            mock_get_object,
+            mock_send_message,
+            mock_copy):
+        copy_helper(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            mock_delete_object,
+            mock_send_message,
+            mock_copy,
+            skip_validation=True)
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
     @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
     @patch('lambda_function.s3_client.get_object')
     @patch('lambda_function.copy_records_metadata')
     @patch('lambda_function.validate_mandatory_fields_exist')
     @patch('lambda_function.validate_formats')
-    @patch.dict(os.environ, {'OUTPUT_BUCKET_NAME': 'destination-bucket'})
-    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
     @patch.dict(os.environ, {'RECORDS_METADATA_BUCKET': 'records-metadata-bucket'})
     def test_copy_calls_copy_records_metadata_when_records_metadata_bucket_set(
-            self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_copy_records_metadata,
-            mock_get_object, mock_send_message, mock_copy, mock_head_object, mock_list_objects):
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        contents = [{'Size': 1024, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-        mock_head_object.return_value = {'ContentLength': 1024}
-        mock_validate_mandatory_fields_exist.return_value = True
-        mock_validate_formats.return_value = True
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_copy_records_metadata,
+            mock_get_object,
+            _mock_send_message,
+            _mock_copy):
+        asset_id = str(uuid.uuid4())
         metadata_object = {
+            "fileId": str(uuid.uuid4()),
             "ConsignmentReference": "TDR-2024-PQXN",
             "FileReference": "ZDSCFC",
             "Series": "SMTH 123",
             "TransferInitiatedDatetime": "2024-09-19 07:21:57",
             "UUID": "0000c951-b332-4d45-93e7-8c24eec4b1f1"
         }
+        mock_validate_mandatory_fields_exist.return_value = True
+        mock_validate_formats.return_value = True
         mock_get_object.return_value = {
             'Body': io.BytesIO(b'[' + json.dumps(metadata_object).encode() + b']')
         }
-        event = {'Records': [{'body': json.dumps({"bucket": "source-bucket", "assetId": asset_id, "metadataLocation": f"s3://metadata-bucket/{asset_id}.metadata"})}]}
-        context = {}
+        event = {'Records': [{'body': json.dumps({
+            "bucket": "source-bucket",
+            "assetId": asset_id,
+            "metadataLocation": f"s3://metadata-bucket/{asset_id}.metadata"
+        })}]}
 
-        lambda_function.lambda_handler(event, context)
+        lambda_function.lambda_handler(event, {})
 
         mock_copy_records_metadata.assert_called_once_with(
             'metadata-bucket', 'records-metadata-bucket', [metadata_object], f'{asset_id}.metadata')
@@ -122,7 +148,7 @@ class TestLambdaFunction(unittest.TestCase):
             json_metadata = [{"Series": "MOCK1 123", "FileReference": "AB/12"}]
 
             lambda_function.copy_records_metadata('source-bucket', 'records-metadata-bucket', json_metadata,
-                                                   'asset-id.metadata')
+                                                  'asset-id.metadata')
 
             mock_get_object.assert_called_once_with(Bucket='records-metadata-bucket', Key='live/MOCK1 123-AB-12.json')
             self.assertEqual(migrated_metadata, json_metadata[0]['migratedMetadata'])
@@ -134,241 +160,144 @@ class TestLambdaFunction(unittest.TestCase):
             uploaded_content = json.loads(call_args[0].getvalue().decode('utf-8'))
             self.assertEqual(json_metadata, uploaded_content)
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
     @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
     @patch('lambda_function.s3_client.get_object')
     @patch('lambda_function.s3_client.delete_objects')
     @patch('lambda_function.validate_mandatory_fields_exist')
     @patch('lambda_function.validate_formats')
-    @patch.dict(os.environ, {'DESTINATION_BUCKET': 'destination-bucket'})
-    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
-    def test_copy_returns_messageId_when_in_body(self, mock_validate_formats, mock_validate_mandatory_fields_exist,
-                                                 mock_delete_objects, mock_get_object, mock_send_message, mock_copy_objects,
-                                                 mock_head_object, mock_list_objects):
-        copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object,
-                    mock_delete_objects, mock_send_message, mock_copy_objects,
-                    mock_head_object, mock_list_objects, potential_message_id="message-id")
+    def test_copy_returns_messageId_when_in_body(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_delete_objects,
+            mock_get_object,
+            mock_send_message,
+            mock_copy_objects):
+        copy_helper(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            mock_delete_objects,
+            mock_send_message,
+            mock_copy_objects,
+            potential_message_id="message-id")
 
-
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
     @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
     @patch('lambda_function.s3_client.get_object')
     @patch('lambda_function.s3_client.delete_objects')
     @patch('lambda_function.validate_mandatory_fields_exist')
     @patch('lambda_function.validate_formats')
-    @patch.dict(os.environ, {'DESTINATION_BUCKET': 'destination-bucket'})
-    @patch.dict(os.environ, {'SOURCE_SYSTEM': 'dri'})
-    def test_copy_returns_files_prefix_if_provided(self, mock_validate_formats, mock_validate_mandatory_fields_exist,
-                                                 mock_delete_objects, mock_get_object, mock_send_message, mock_copy_objects,
-                                                 mock_head_object, mock_list_objects):
-        copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object,
-                    mock_delete_objects, mock_send_message, mock_copy_objects,
-                    mock_head_object, mock_list_objects, potential_files_prefix="v1/test/prefix")
+    def test_copy_returns_files_prefix_if_provided(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_delete_objects,
+            mock_get_object,
+            mock_send_message,
+            mock_copy_objects):
+        copy_helper(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            mock_delete_objects,
+            mock_send_message,
+            mock_copy_objects,
+            potential_files_prefix="v1/test/prefix")
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
-    @patch('lambda_function.s3_client.copy_object')
-    @patch('lambda_function.validate_metadata')
-    def test_copy_object_failure(self, mock_validate_metadata, mock_copy_object, mock_head_object, mock_list_objects):
-        content_length = 1024
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        contents = [{'Size': content_length, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-        mock_head_object.return_value = {'ContentLength': content_length}  # 1 KB
-        mock_validate_metadata.return_value = True
-        mock_copy_object.side_effect = Exception("S3 copy_object failed")
-        event = {
-            'Records': [
-                {'body': f'{{"bucket": "source-bucket","fileId":"{asset_id}", "metadataLocation":"s3://metadata-bucket/{asset_id}.metadata"}}'}
-            ]
-        }
-        context = {}
+    @patch('lambda_function.copy_objects')
+    @patch('lambda_function.s3_client.get_object')
+    @patch('lambda_function.validate_mandatory_fields_exist')
+    @patch('lambda_function.validate_formats')
+    def test_copy_failure_raises_exception(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            mock_copy_objects):
+        asset_id = str(uuid.uuid4())
+        metadata = [dict(self.valid_metadata(), fileId=str(uuid.uuid4()))]
+        mock_get_object.return_value = {'Body': io.BytesIO(json.dumps(metadata).encode('utf-8'))}
+        mock_validate_mandatory_fields_exist.return_value = True
+        mock_validate_formats.return_value = True
+        mock_copy_objects.side_effect = Exception("S3 copy failed")
+        event = {'Records': [{'body': json.dumps({
+            "bucket": "source-bucket",
+            "assetId": asset_id,
+            "metadataLocation": f"s3://metadata-bucket/{asset_id}.metadata"
+        })}]}
+
         with self.assertRaises(Exception) as cm:
-            lambda_function.lambda_handler(event, context)
-        self.assertEqual("S3 copy_object failed", str(cm.exception))
+            lambda_function.lambda_handler(event, {})
+        self.assertEqual("S3 copy failed", str(cm.exception))
 
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
-    @patch('lambda_function.s3_client.create_multipart_upload')
-    @patch('lambda_function.s3_client.upload_part_copy')
-    @patch('lambda_function.s3_client.complete_multipart_upload')
-    @patch('lambda_function.s3_client.abort_multipart_upload')
-    @patch('lambda_function.validate_metadata')
-    def test_multipart_upload_failure(self, mock_validate_metadata, abort_multipart_upload, __,
-                                      mock_upload_part_copy, mock_create_multipart_upload,
-                                      mock_head_object, mock_list_objects):
-        content_length = 5 * 1024 * 1024 * 1024
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        contents = [{'Size': content_length, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-        mock_head_object.return_value = {'ContentLength': content_length}
-        mock_create_multipart_upload.return_value = {'UploadId': 'test-upload-id'}
-
-        mock_upload_part_copy.side_effect = Exception("S3 upload_part_copy failed")
-        mock_validate_metadata.return_value = True
-
-        event = {
-            'Records': [
-                {'body': f'{{"bucket": "source-bucket","fileId":"{asset_id}","metadataLocation":"s3://metadata-bucket/{asset_id}.metadata"}}'}
-            ]
-        }
-        context = {}
-        with self.assertRaises(Exception) as cm:
-            lambda_function.lambda_handler(event, context)
-        self.assertEqual("S3 upload_part_copy failed", str(cm.exception))
-        expected_abort_call = {'Bucket': 'destination-bucket', 'Key': key, 'UploadId': 'test-upload-id'}
-        self.assertEqual(expected_abort_call, abort_multipart_upload.call_args_list[0][1])
-
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
-    @patch('lambda_function.s3_client.create_multipart_upload')
-    @patch('lambda_function.s3_client.upload_part_copy')
-    @patch('lambda_function.s3_client.complete_multipart_upload')
-    @patch('lambda_function.s3_client.abort_multipart_upload')
-    @patch('lambda_function.validate_metadata')
-    def test_complete_multipart_upload_failure(self, mock_validate_metadata, abort_multipart_upload,
-                                               mock_complete_multipart_upload,
-                                               mock_upload_part_copy, mock_create_multipart_upload, mock_head_object, mock_list_objects):
-
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        content_length = 5 * 1024 * 1024 * 1024
-        contents = [{'Size': content_length, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-        mock_head_object.return_value = {'ContentLength': content_length}
-        mock_create_multipart_upload.return_value = {'UploadId': 'test-upload-id'}
-        mock_upload_part_copy.return_value = {'CopyPartResult': {'ETag': 'etag'}}
-        mock_validate_metadata.return_value = True
-        mock_complete_multipart_upload.side_effect = Exception("S3 complete_multipart_upload failed")
-
-        event = {
-            'Records': [
-                {'body': f'{{"bucket": "source-bucket","metadataLocation":"s3://metadata-bucket/{asset_id}","fileId":"{asset_id}"}}'}
-            ]
-        }
-        context = {}
-        with self.assertRaises(Exception) as cm:
-            lambda_function.lambda_handler(event, context)
-        self.assertEqual("S3 complete_multipart_upload failed", str(cm.exception))
-        expected_abort_call = {'Bucket': 'destination-bucket', 'Key': key, 'UploadId': 'test-upload-id'}
-        self.assertEqual(expected_abort_call, abort_multipart_upload.call_args_list[0][1])
-
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
-    @patch('lambda_function.s3_client.copy_object')
     @patch('lambda_function.sqs_client.send_message')
-    @patch('lambda_function.validate_metadata')
-    def test_send_message_failure(self, mock_validate_metadata, mock_send_message, _, mock_head_object,
-                                  mock_list_objects):
-        content_length = 1024
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        contents = [{'Size': content_length, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-        mock_head_object.return_value = {'ContentLength': content_length}
-        mock_validate_metadata.return_value = True
-        event = {
-            'Records': [
-                {'body': f'{{"bucket": "source-bucket","fileId":"{asset_id}","metadataLocation":"s3://metadata-bucket/{asset_id}.metadata"}}'}
-            ]
-        }
-        context = {}
+    @patch('lambda_function.copy_objects')
+    @patch('lambda_function.s3_client.get_object')
+    @patch('lambda_function.validate_mandatory_fields_exist')
+    @patch('lambda_function.validate_formats')
+    def test_send_message_failure(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_get_object,
+            _mock_copy_objects,
+            mock_send_message):
+        asset_id = str(uuid.uuid4())
+        metadata = [dict(self.valid_metadata(), fileId=str(uuid.uuid4()))]
+        mock_get_object.return_value = {'Body': io.BytesIO(json.dumps(metadata).encode('utf-8'))}
+        mock_validate_mandatory_fields_exist.return_value = True
+        mock_validate_formats.return_value = True
         mock_send_message.side_effect = Exception("SQS Send message failed")
+        event = {'Records': [{'body': json.dumps({
+            "bucket": "source-bucket",
+            "assetId": asset_id,
+            "metadataLocation": f"s3://metadata-bucket/{asset_id}.metadata"
+        })}]}
 
         with self.assertRaises(Exception) as cm:
-            lambda_function.lambda_handler(event, context)
+            lambda_function.lambda_handler(event, {})
         self.assertEqual("SQS Send message failed", str(cm.exception))
 
     @patch('lambda_function.s3_client.delete_objects')
-    @patch('lambda_function.s3_client.list_objects')
-    @patch('lambda_function.s3_client.head_object')
-    @patch('lambda_function.s3_client.copy_object')
+    @patch('lambda_function.s3_client.get_object')
+    @patch('lambda_function.copy_objects')
     @patch('lambda_function.sqs_client.send_message')
-    @patch('lambda_function.validate_metadata')
+    @patch('lambda_function.validate_mandatory_fields_exist')
+    @patch('lambda_function.validate_formats')
     @patch.dict(os.environ, {'DELETE_FROM_SOURCE': 'true'})
-    def test_delete_failure_should_not_send_message(self, mock_validate_metadata, mock_send_message, _, mock_head_object,
-                                  mock_list_objects, mock_delete_objects):
-        content_length = 1024
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        contents = [{'Size': content_length, 'Key': key}, {'Size': 1, 'Key': f'{asset_id}.metadata'}]
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-        mock_head_object.return_value = {'ContentLength': content_length}
-        mock_validate_metadata.return_value = True
-        event = {
-            'Records': [
-                {'body': f'{{"bucket": "source-bucket","fileId":"{asset_id}","metadataLocation":"s3://metadata-bucket/{asset_id}.metadata"}}'}
-            ]
-        }
-        context = {}
+    def test_delete_failure_should_not_send_message(
+            self,
+            mock_validate_formats,
+            mock_validate_mandatory_fields_exist,
+            mock_send_message,
+            _mock_copy_objects,
+            mock_get_object,
+            mock_delete_objects):
+        asset_id = str(uuid.uuid4())
+        metadata = [dict(self.valid_metadata(), fileId=str(uuid.uuid4())) for _ in range(2)]
+        mock_get_object.return_value = {'Body': io.BytesIO(json.dumps(metadata).encode('utf-8'))}
+        mock_validate_mandatory_fields_exist.return_value = True
+        mock_validate_formats.return_value = True
         mock_delete_objects.side_effect = Exception("Delete object failed")
+        event = {'Records': [{'body': json.dumps({
+            "bucket": "source-bucket",
+            "assetId": asset_id,
+            "metadataLocation": f"s3://metadata-bucket/{asset_id}.metadata"
+        })}]}
 
         with self.assertRaises(Exception) as cm:
-            lambda_function.lambda_handler(event, context)
+            lambda_function.lambda_handler(event, {})
         self.assertEqual("Delete object failed", str(cm.exception))
-
         self.assertEqual(0, mock_send_message.call_count)
 
     def test_should_successfully_validate_when_the_fields_are_valid(self):
-        mock_response_body = json.dumps(self.valid_metadata())
         schema_location = "common/preingest-tdr/metadata-schema.json"
-        result = lambda_function.validate_mandatory_fields_exist(schema_location, json.loads(mock_response_body))
+        result = lambda_function.validate_mandatory_fields_exist(schema_location, self.valid_metadata())
         self.assertEqual(True, result)
-
-    @patch('lambda_function.s3_client.list_objects')
-    def test_should_raise_an_exception_when_the_file_does_not_exist_in_source_bucket(self, mock_list_objects):
-        error_response = {
-            'Error': {
-                'Code': '404',
-                'Message': 'Not Found'
-            }
-        }
-
-        client_error = ClientError(error_response, 'ListObjects')
-
-        mock_list_objects.side_effect = client_error
-        with self.assertRaises(Exception) as ex:
-            lambda_function.assert_objects_exist_in_bucket('some_bucket', 'some_key')
-
-        self.assertEqual(
-            "Object 'some_key' does not exist in 'some_bucket', underlying error is: 'An error occurred (404) when "
-            "calling the ListObjects operation: Not Found'",
-            str(ex.exception))
-
-    @patch('lambda_function.s3_client.list_objects')
-    def test_should_add_trailing_slash_to_prefix_if_missing(self, mock_list_objects):
-        contents = [{'Key': 'test'}]
-        mock_list_objects.side_effect = [{'Contents': contents, 'IsTruncated': False}]
-        lambda_function.assert_objects_exist_in_bucket('some_bucket', 'some_key')
-        self.assertEqual(mock_list_objects.call_args.kwargs['Prefix'], 'some_key/')
-
-    @patch('lambda_function.s3_client.list_objects')
-    def test_keep_trailing_slash_on_prefix_if_included(self, mock_list_objects):
-        contents = [{'Key': 'test'}]
-        mock_list_objects.side_effect = [{'Contents': contents, 'IsTruncated': False}]
-        lambda_function.assert_objects_exist_in_bucket('some_bucket', 'some_key/')
-        self.assertEqual(mock_list_objects.call_args.kwargs['Prefix'], 'some_key/')
-
-    @patch('lambda_function.s3_client.list_objects')
-    def test_should_raise_exception_when_file_exists_but_corresponding_metadata_file_does_not_exist_in_source_bucket(
-            self, mock_list_objects):
-        asset_id, file_id = str(uuid.uuid4()), str(uuid.uuid4())
-        key = f'{asset_id}/{file_id}'
-        contents = []
-        mock_list_objects.return_value = {'Contents': contents, 'IsTruncated': False}
-
-        with self.assertRaises(Exception) as ex:
-            lambda_function.assert_objects_exist_in_bucket('some_bucket', 'some_key')
-
-        self.assertEqual(
-            "Asset 'some_key' has no files in 'some_bucket'",
-            str(ex.exception))
 
     def test_should_raise_an_exception_if_fields_are_missing(self):
         schema_location = "common/preingest-tdr/metadata-schema.json"
@@ -376,12 +305,10 @@ class TestLambdaFunction(unittest.TestCase):
             metadata_schema = json.load(metadata_schema_file)
         required_fields = metadata_schema["required"]
         for field in required_fields:
-
             invalid_metadata = self.valid_metadata().copy()
             invalid_metadata.pop(field)
 
             with self.assertRaises(Exception) as ex:
-
                 lambda_function.validate_mandatory_fields_exist(schema_location, invalid_metadata)
             self.assertEqual(f"'{field}' is a required property", str(ex.exception))
 
@@ -401,7 +328,7 @@ class TestLambdaFunction(unittest.TestCase):
             elif type(property_value_type) is list and "string" in property_value_type and "null" in property_value_type:
                 test_values = [1, False, ["test"], {"test": "value"}]
             else:
-                raise "Unexpected property value"
+                raise Exception("Unexpected property value")
 
             for test_value in test_values:
                 invalid_metadata = self.valid_metadata().copy()
@@ -420,21 +347,17 @@ class TestLambdaFunction(unittest.TestCase):
                 self.assertEqual(err_msg, str(ex.exception))
 
     def test_should_raise_an_exception_when_UUID_is_invalid(self):
-        mock_response_body = """{"ConsignmentReference": "TDR-2024-PQXN", "FileReference": "ZDSCFC", "Series":"MOCK1 123", 
-                "TransferInitiatedDatetime": "2024-09-19 07:21:57", "UUID": "invalid-uuid-format"}"""
+        mock_response_body = """{"ConsignmentReference": "TDR-2024-PQXN", "FileReference": "ZDSCFC", "Series":"MOCK1 123", "TransferInitiatedDatetime": "2024-09-19 07:21:57", "UUID": "invalid-uuid-format"}"""
 
         with self.assertRaises(Exception) as ex:
-            lambda_function.validate_formats(json.loads(mock_response_body), 'any_bucket_patched', 'any_key_patched')
-        self.assertEqual("Unable to parse UUID, 'invalid-uuid-format' from file 'any_key_patched' in "
-                         "bucket 'any_bucket_patched'. Invalid format", str(ex.exception))
+            lambda_function.validate_formats(json.loads(mock_response_body))
+        self.assertEqual("Unable to parse UUID, 'invalid-uuid-format' from file. Invalid format", str(ex.exception))
 
     def test_should_raise_an_exception_when_series_is_empty(self):
         mock_response_body = """{"ConsignmentReference": "TDR-2024-PQXN", "FileReference": "ZDSCFC", "Series": " ", "TransferInitiatedDatetime": "2024-09-19 07:21:57", "UUID": "bb7bb923-b82c-4203-a3c1-ea3f362ef4da"}"""
         with self.assertRaises(Exception) as ex:
-            lambda_function.validate_formats(json.loads(mock_response_body), 'any_bucket_patched', 'any_key_patched')
-        self.assertEqual(
-            "Empty Series value in file 'any_key_patched' in bucket 'any_bucket_patched'. Unable to proceed",
-            str(ex.exception))
+            lambda_function.validate_formats(json.loads(mock_response_body))
+        self.assertEqual("Empty Series value in file. Unable to proceed", str(ex.exception))
 
     def test_should_raise_an_exception_when_series_format_is_invalid(self):
         invalid_series_names = ["MOCK1 12345", "1LEV 12", "abc 12", "MOCKT 1", "UNKNOWN", "LEV 2   ", "FLM 012",
@@ -442,19 +365,16 @@ class TestLambdaFunction(unittest.TestCase):
         for invalid_series in invalid_series_names:
             mock_response_body = f"""{{"ConsignmentReference": "TDR-2024-PQXN", "FileReference": "ZDSCFC", "Series": "{invalid_series}", "TransferInitiatedDatetime": "2024-09-19 07:21:57", "UUID": "bb7bb923-b82c-4203-a3c1-ea3f362ef4da"}}"""
             with self.assertRaises(Exception) as ex:
-                lambda_function.validate_formats(json.loads(mock_response_body), 'any_bucket_patched',
-                                                 'any_key_patched')
+                lambda_function.validate_formats(json.loads(mock_response_body))
             self.assertEqual(
-                f"Invalid Series value, '{invalid_series}' in file 'any_key_patched' in bucket 'any_bucket_patched'. Unable to proceed",
+                f"Invalid Series value, '{invalid_series}' in file. Unable to proceed",
                 str(ex.exception))
 
     def test_should_successfully_validate_various_allowed_formats_of_series_name(self):
         valid_series_names = ["MOCK1 123", "Unknown", "UKSC 1", "LEV 2", "PRO 234", "A 7"]
         for valid_series in valid_series_names:
             mock_response_body = f"""{{"ConsignmentReference": "TDR-2024-PQXN", "FileReference": "ZDSCFC", "Series": "{valid_series}", "TransferInitiatedDatetime": "2024-09-19 07:21:57", "UUID": "bb7bb923-b82c-4203-a3c1-ea3f362ef4da"}}"""
-            self.assertEqual(True,
-                             lambda_function.validate_formats(json.loads(mock_response_body), 'any_bucket_patched',
-                                                              'any_key_patched'))
+            self.assertEqual(True, lambda_function.validate_formats(json.loads(mock_response_body)))
 
 
 if __name__ == '__main__':

--- a/python/lambdas/preingest-importer/test_utils.py
+++ b/python/lambdas/preingest-importer/test_utils.py
@@ -5,39 +5,49 @@ import uuid
 import lambda_function
 
 
-def copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exist, mock_get_object, mock_delete_object,
-                mock_send_message, mock_copy,
-                mock_head_object, mock_list_objects, potential_message_id=None, should_delete=False, skip_validation=False, potential_files_prefix=None):
-    content_length = 5 * 1024 * 1024 * 1024
+def copy_helper(
+        self,
+        mock_validate_formats,
+        mock_validate_mandatory_fields_exist,
+        mock_get_object,
+        mock_delete_object,
+        mock_send_message,
+        mock_copy,
+        potential_message_id=None,
+        should_delete=False,
+        skip_validation=False,
+        potential_files_prefix=None):
     asset_id = str(uuid.uuid4())
-    def key(): return f'{asset_id}/{str(uuid.uuid4())}'
     body_json = {"bucket": "source-bucket", "assetId": asset_id, "metadataLocation": f"s3://metadata-bucket/{asset_id}.metadata"}
     if potential_files_prefix:
         body_json['filesPrefix'] = potential_files_prefix
 
-    expected_message_body = {"id": asset_id, "location": f"s3://destination-bucket/{asset_id}.metadata", "filesPrefix": potential_files_prefix if potential_files_prefix else asset_id}
+    files_prefix = potential_files_prefix if potential_files_prefix else asset_id
+    expected_message_body = {
+        "id": asset_id,
+        "location": f"s3://destination-bucket/{asset_id}.metadata",
+        "filesPrefix": files_prefix
+    }
     if potential_message_id:
         body_json['messageId'] = potential_message_id
         expected_message_body['messageId'] = potential_message_id
 
     body = {'body': json.dumps(body_json)}
-    content_files = [{'Size': content_length, 'Key': key()} for _ in range(0, 1000)]
-    content_files.append({'Size': 1, 'Key': f'{asset_id}.metadata'})
-    empty_response = {'Contents': [], 'IsTruncated': False}
-    mock_list_objects.side_effect = [{'Contents': content_files, 'IsTruncated': True}, empty_response]
-    mock_head_object.return_value = {'ContentLength': content_length}
+    file_count = 1001 if should_delete else 2
+    file_ids = [str(uuid.uuid4()) for _ in range(file_count)]
     mock_validate_mandatory_fields_exist.return_value = True
     mock_validate_formats.return_value = True
-    metadata_object = {
+    metadata_object = lambda file_id: {
+        "fileId": file_id,
         "ConsignmentReference": "TDR-2024-PQXN",
         "FileReference": "ZDSCFC",
         "Series": "SMTH 123",
         "TransferInitiatedDatetime": "2024-09-19 07:21:57",
         "UUID": "0000c951-b332-4d45-93e7-8c24eec4b1f1"
     }
+    metadata_objects = [metadata_object(file_id) for file_id in file_ids]
     mock_get_object.return_value = {
-        'Body': io.BytesIO(
-            b'[' + json.dumps(metadata_object).encode() + b']'),
+        'Body': io.BytesIO(json.dumps(metadata_objects).encode('utf-8')),
     }
 
     event = {'Records': [body]}
@@ -47,33 +57,27 @@ def copy_helper(self, mock_validate_formats, mock_validate_mandatory_fields_exis
     expected_sqs_args = {'MessageBody': json.dumps(expected_message_body), 'QueueUrl': 'destination-queue'}
 
     self.assertEqual(2, mock_copy.call_count)
-    self.assertEqual(2, mock_list_objects.call_count)
-
-    self.assertEqual('destination-bucket', mock_copy.call_args_list[0].args[0])
-    self.assertEqual(sorted([f['Key'] for f in content_files]), sorted(mock_copy.call_args_list[0].args[1]))
-
-
-    self.assertEqual(2, mock_copy.call_count)
+    expected_transfer_files = [f'{files_prefix}/{file_id}' for file_id in file_ids]
+    self.assertEqual(('destination-bucket', expected_transfer_files, 'source-bucket'), mock_copy.call_args_list[0].args)
+    self.assertEqual(('destination-bucket', [f'{asset_id}.metadata'], 'metadata-bucket'), mock_copy.call_args_list[1].args)
     self.assertEqual(expected_sqs_args, mock_send_message.call_args_list[0][1])
 
     if skip_validation:
         mock_validate_mandatory_fields_exist.assert_not_called()
         mock_validate_formats.assert_not_called()
-        mock_get_object.assert_not_called()
     else:
-        mock_validate_mandatory_fields_exist.assert_called_once()
-        validate_args = mock_validate_mandatory_fields_exist.call_args_list[0].args
-        self.assertEqual('common/preingest-dri/metadata-schema.json', validate_args[0])
-        self.assertEqual(metadata_object, validate_args[1])
-        mock_validate_formats.assert_called_once()
-        validate_format_args = mock_validate_formats.call_args_list[0].args
-        self.assertEqual(metadata_object, validate_format_args[0])
-        self.assertEqual('metadata-bucket', validate_format_args[1])
-        self.assertEqual(f'{asset_id}.metadata', validate_format_args[2])
-        mock_get_object.assert_called_once()
-        get_object_args = mock_get_object.call_args_list[0].kwargs
-        self.assertEqual('metadata-bucket', get_object_args['Bucket'])
-        self.assertEqual(f'{asset_id}.metadata', get_object_args['Key'])
+        self.assertEqual(file_count, mock_validate_mandatory_fields_exist.call_count)
+        self.assertEqual(file_count, mock_validate_formats.call_count)
+        first_validate_args = mock_validate_mandatory_fields_exist.call_args_list[0].args
+        self.assertEqual('common/preingest-dri/metadata-schema.json', first_validate_args[0])
+        self.assertEqual(metadata_objects[0], first_validate_args[1])
+        first_validate_format_args = mock_validate_formats.call_args_list[0].args
+        self.assertEqual(metadata_objects[0], first_validate_format_args[0])
+
+    mock_get_object.assert_called_once()
+    get_object_args = mock_get_object.call_args_list[0].kwargs
+    self.assertEqual('metadata-bucket', get_object_args['Bucket'])
+    self.assertEqual(f'{asset_id}.metadata', get_object_args['Key'])
 
     if should_delete:
         self.assertEqual(2, mock_delete_object.call_count)

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/archive_folder_all_fields_missing.json
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/archive_folder_all_fields_missing.json
@@ -5,7 +5,7 @@
     }
   ],
   "expectedErrors": [
-    "Attempt to decode value on failed cursor: DownField(id)",
-    "Attempt to decode value on failed cursor: DownField(name)"
+    "DecodingFailure at .id: Missing required field",
+    "DecodingFailure at .name: Missing required field"
   ]
 }

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/asset_all_fields_missing.json
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/asset_all_fields_missing.json
@@ -5,12 +5,12 @@
     }
   ],
   "expectedErrors": [
-    "Attempt to decode value on failed cursor: DownField(digitalAssetSource)",
-    "Attempt to decode value on failed cursor: DownField(filePath)",
-    "Attempt to decode value on failed cursor: DownField(id)",
-    "Attempt to decode value on failed cursor: DownField(name)",
-    "Attempt to decode value on failed cursor: DownField(originalMetadataFiles)",
-    "Attempt to decode value on failed cursor: DownField(title)",
-    "Attempt to decode value on failed cursor: DownField(upstreamSystem)"
+    "DecodingFailure at .digitalAssetSource: Missing required field",
+    "DecodingFailure at .filePath: Missing required field",
+    "DecodingFailure at .id: Missing required field",
+    "DecodingFailure at .name: Missing required field",
+    "DecodingFailure at .originalMetadataFiles: Missing required field",
+    "DecodingFailure at .title: Missing required field",
+    "DecodingFailure at .upstreamSystem: Missing required field"
   ]
 }

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/asset_invalid_upstream_system.json
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/asset_invalid_upstream_system.json
@@ -20,6 +20,6 @@
     }
   ],
   "expectedErrors": [
-    "Invalid display name encountered for source system: InvalidSystem"
+    "DecodingFailure at : Invalid display name encountered for source system: InvalidSystem"
   ]
 }

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/content_folder_all_fields_missing.json
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/content_folder_all_fields_missing.json
@@ -5,7 +5,7 @@
     }
   ],
   "expectedErrors": [
-    "Attempt to decode value on failed cursor: DownField(id)",
-    "Attempt to decode value on failed cursor: DownField(name)"
+    "DecodingFailure at .id: Missing required field",
+    "DecodingFailure at .name: Missing required field"
   ]
 }

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/file_all_fields_missing.json
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/file_all_fields_missing.json
@@ -5,13 +5,13 @@
     }
   ],
   "expectedErrors": [
-    "Attempt to decode value on failed cursor: DownField(fileSize)",
-    "Attempt to decode value on failed cursor: DownField(id)",
-    "Attempt to decode value on failed cursor: DownField(location)",
-    "Attempt to decode value on failed cursor: DownField(name)",
-    "Attempt to decode value on failed cursor: DownField(representationSuffix)",
-    "Attempt to decode value on failed cursor: DownField(representationType)",
-    "Attempt to decode value on failed cursor: DownField(sortOrder)",
-    "Attempt to decode value on failed cursor: DownField(title)"
+    "DecodingFailure at .fileSize: Missing required field",
+    "DecodingFailure at .id: Missing required field",
+    "DecodingFailure at .location: Missing required field",
+    "DecodingFailure at .name: Missing required field",
+    "DecodingFailure at .representationSuffix: Missing required field",
+    "DecodingFailure at .representationType: Missing required field",
+    "DecodingFailure at .sortOrder: Missing required field",
+    "DecodingFailure at .title: Missing required field"
   ]
 }

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/file_mandatory_fields.json
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/resources/inputjson/file_mandatory_fields.json
@@ -11,7 +11,7 @@
     }
   ],
   "expectedErrors": [
-    "Attempt to decode value on failed cursor: DownField(fileSize)",
-    "Attempt to decode value on failed cursor: DownField(title)"
+    "DecodingFailure at .fileSize: Missing required field",
+    "DecodingFailure at .title: Missing required field"
   ]
 }

--- a/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/scala/uk/gov/nationalarchives/ingestvalidategenericingestinputs/LambdaTest.scala
+++ b/scala/lambdas/ingest-validate-generic-ingest-inputs/src/test/scala/uk/gov/nationalarchives/ingestvalidategenericingestinputs/LambdaTest.scala
@@ -19,8 +19,6 @@ class LambdaTest extends AnyFunSpec with TableDrivenPropertyChecks:
     forAll(inputFiles) { inputFileName =>
       it(s"should validate the input file $inputFileName") {
         val (expectedErrors, errors) = runLambda(inputFileName)
-        import io.circe.syntax.*
-        println(errors.asJson.noSpaces)
         expectedErrors should equal(errors)
       }
     }

--- a/scala/lambdas/postprocess-cleanup-handler/src/test/scala/uk/gov/nationalarchives/postprocesscleanup/LambdaTest.scala
+++ b/scala/lambdas/postprocess-cleanup-handler/src/test/scala/uk/gov/nationalarchives/postprocesscleanup/LambdaTest.scala
@@ -89,7 +89,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
     val result = runLambda(sqsEvent, List(initialFileItem), Map.empty)
     result.result.isLeft should equal(true)
     result.result.left.value.getMessage should equal(
-      "Failed to decode SQS message body: Attempt to decode value on failed cursor: DownField(assetId),DownField(parameters)"
+      "Failed to decode SQS message body: DecodingFailure at .parameters.assetId: Missing required field"
     )
   }
 

--- a/terraform/preingest/importer.tf
+++ b/terraform/preingest/importer.tf
@@ -5,7 +5,7 @@ locals {
   sse_encryption            = "sse"
   visibility_timeout        = 180
   redrive_maximum_receives  = 5
-  source_bucket_permissions = jsonencode(var.delete_from_source ? ["s3:GetObject", "s3:GetObjectTagging", "s3:ListBucket", "s3:DeleteObject"] : ["s3:GetObject", "s3:GetObjectTagging", "s3:ListBucket"])
+  source_bucket_permissions = jsonencode(var.delete_from_source ? ["s3:GetObject", "s3:GetObjectTagging", "s3:DeleteObject"] : ["s3:GetObject", "s3:GetObjectTagging"])
 }
 module "dr2_importer_lambda" {
   source          = "git::https://github.com/nationalarchives/da-terraform-modules//lambda"

--- a/terraform/preingest/templates/copy_files_no_kms_policy.json.tpl
+++ b/terraform/preingest/templates/copy_files_no_kms_policy.json.tpl
@@ -14,8 +14,7 @@
       "Action": [
         "s3:PutObject*",
         "s3:GetObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ],
       "Effect": "Allow",
       "Resource": [

--- a/terraform/preingest/templates/copy_files_with_kms_policy.json.tpl
+++ b/terraform/preingest/templates/copy_files_with_kms_policy.json.tpl
@@ -22,8 +22,7 @@
       "Action": [
         "s3:PutObject*",
         "s3:GetObject",
-        "s3:DeleteObject",
-        "s3:ListBucket"
+        "s3:DeleteObject"
       ],
       "Effect": "Allow",
       "Resource": [


### PR DESCRIPTION
In the non courtdoc importers, we’re currently doing list_bucket with a prefix of the `assetId` or `filesPrefix` and copying all of those objects across. The problem with this is that we have to trust that the source hasn’t copied files under that prefix without including them in the metadata file.

It also means that the lambda needs ListBucket permissions.

The more accurate way to do this is to construct the S3 keys using the ids from the metadata and copy those. So we read the metadata and construct a list of keys which are `{assetId or filesPrefix}/{fileId}`

If anything upstream isn’t following this convention then they should be.

I've removed the permissions from the importer side.
