### PR TITLE
Allow all GetObject calls for external buckets.

### DIFF
--- a/terraform/templates/vpc/s3_endpoint_policy.json.tpl
+++ b/terraform/templates/vpc/s3_endpoint_policy.json.tpl
@@ -19,7 +19,7 @@
       "Principal": "*",
       "Action": [
         "s3:ListBucket",
-        "s3:GetObject",
+        "s3:GetObject*",
         "s3:PutObject"
       ],
       "Resource": [


### PR DESCRIPTION
This will allow us to get objects with tags.
