### PR TITLE
DR2-2929 Don't copy tags or annotations

### DIFF
--- a/python/lambdas/preingest-importer/lambda_function.py
+++ b/python/lambdas/preingest-importer/lambda_function.py
@@ -107,7 +107,7 @@ def copy_objects(destination_bucket, s3_keys, source_bucket):
     for s3_key in s3_keys:
         try:
             copy_source = {"Bucket": source_bucket, "Key": s3_key}
-            s3_client.copy(copy_source, destination_bucket, s3_key)
+            s3_client.copy(copy_source, destination_bucket, s3_key, {"TaggingDirective": "REPLACE", "AnnotationDirective": "EXCLUDE"})
         except Exception as e:
             print(f"Error during copy of '{s3_key}' from '{source_bucket}' to '{destination_bucket}': {e}")
             raise e

--- a/python/lambdas/preingest-importer/lambda_function_test.py
+++ b/python/lambdas/preingest-importer/lambda_function_test.py
@@ -377,5 +377,15 @@ class TestLambdaFunction(unittest.TestCase):
             self.assertEqual(True, lambda_function.validate_formats(json.loads(mock_response_body)))
 
 
+    @patch('lambda_function.s3_client.copy')
+    def test_copy_objects_should_pass_the_correct_arguments_to_s3_call(self, mock_s3_copy):
+        lambda_function.copy_objects("destination", ["key"], "source")
+        args = mock_s3_copy.call_args_list[0].args
+        self.assertDictEqual({"Bucket": "source", "Key": "key"}, args[0])
+        self.assertEqual("destination", args[1])
+        self.assertEqual("key", args[2])
+        self.assertDictEqual({"TaggingDirective": "REPLACE", "AnnotationDirective": "EXCLUDE"}, args[3])
+
+
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
There are a load of permissions missing for copying objects with tags like those that come from the central bucket.
We don't need the tags for the DR2 ingest so they can be removed when we copy the files over.
