### PR TITLE
Remove extra arg for AnnotationDirective

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   private val log4CatsVersion = "2.8.0"
   private val awsLibraryVersion = "1.12.797"
   private lazy val scalaTestVersion = "3.2.20"
-  private lazy val nettyVersion = "4.2.15.Final"
+  private lazy val nettyVersion = "4.2.16.Final"
   private lazy val jacksonVersion = "3.2.1"
 
   lazy val awsCrt = "software.amazon.awssdk.crt" % "aws-crt" % "0.47.2"

--- a/python/lambdas/preingest-importer/lambda_function.py
+++ b/python/lambdas/preingest-importer/lambda_function.py
@@ -107,7 +107,7 @@ def copy_objects(destination_bucket, s3_keys, source_bucket):
     for s3_key in s3_keys:
         try:
             copy_source = {"Bucket": source_bucket, "Key": s3_key}
-            s3_client.copy(copy_source, destination_bucket, s3_key, {"TaggingDirective": "REPLACE", "AnnotationDirective": "EXCLUDE"})
+            s3_client.copy(copy_source, destination_bucket, s3_key, {"TaggingDirective": "REPLACE"})
         except Exception as e:
             print(f"Error during copy of '{s3_key}' from '{source_bucket}' to '{destination_bucket}': {e}")
             raise e

--- a/python/lambdas/preingest-importer/lambda_function_test.py
+++ b/python/lambdas/preingest-importer/lambda_function_test.py
@@ -384,7 +384,7 @@ class TestLambdaFunction(unittest.TestCase):
         self.assertDictEqual({"Bucket": "source", "Key": "key"}, args[0])
         self.assertEqual("destination", args[1])
         self.assertEqual("key", args[2])
-        self.assertDictEqual({"TaggingDirective": "REPLACE", "AnnotationDirective": "EXCLUDE"}, args[3])
+        self.assertDictEqual({"TaggingDirective": "REPLACE"}, args[3])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We don't really need this at the moment and it's such a recent addition to boto3 that it's not included in the boto version that lambda has bundled

It's easier to remove it for now and add it back in later if necessary.
