### PR TITLE
DR2-2930 Stop assuming a role in the DRI migration script

### DIFF
--- a/python/dri-migration/create_ingest_metadata_test.py
+++ b/python/dri-migration/create_ingest_metadata_test.py
@@ -45,10 +45,9 @@ def setup_test(mock_checksum, mock_connect, mock_create_skeleton, rows, mock_wri
     mock_write_to_ic_db.return_value = True
 
 
-def verify_function_calls(test: "TestMigrate", is_test_run, get_clients: Mock, mock_connect: Mock,
+def verify_function_calls(test: "TestMigrate", is_test_run, mock_connect: Mock,
                           mock_create_skeleton: Mock, mock_checksum: Mock, write_to_ic_db: Mock, ref_error_thrown=False):
 
-    get_clients.assert_called_with("123456789", "testenv")
     mock_connect.assert_called_with(dsn="localhost/SDB4", user="STORE", password="password")
     if ref_error_thrown:
        mock_create_skeleton.assert_called_with(["fmt", "x-fmt"])
@@ -84,9 +83,10 @@ class TestMigrate(unittest.TestCase):
     @patch('builtins.open', new_callable=mock_open, read_data="SELECT * FROM TEST")
     @patch('migrate.create_ingest_metadata.create_skeleton_suite_lookup')
     @patch('migrate.create_ingest_metadata.calculate_checksum')
-    @patch('migrate.create_ingest_metadata.get_clients')
+    @patch('migrate.create_ingest_metadata.sqs_client')
+    @patch('migrate.create_ingest_metadata.s3_client')
     def test_migrate_s3_sqs(
-            self, test_run, checksum, get_clients, mock_checksum,
+            self, test_run, checksum, mock_s3, mock_sqs, mock_checksum,
             mock_create_skeleton, mock_open_file, __, mock_connect, write_to_ic_db
     ):
         row_fmt = [
@@ -104,10 +104,6 @@ class TestMigrate(unittest.TestCase):
         rows = [row_fmt, row_x_fmt]
 
         setup_test(mock_checksum, mock_connect, mock_create_skeleton, rows, write_to_ic_db, test_run)
-
-        mock_s3 = MagicMock()
-        mock_sqs = MagicMock()
-        get_clients.return_value = (mock_s3, mock_sqs,)
 
         create_ingest_metadata.migrate(self.ic_db_name)
 
@@ -180,7 +176,7 @@ class TestMigrate(unittest.TestCase):
             self.assertEqual(f"v1/{metadata_uuid}", sent_body["filesPrefix"])
 
         is_test_run = test_run == "true" or test_run is None
-        verify_function_calls(self, is_test_run, get_clients, mock_connect, mock_create_skeleton, mock_checksum,
+        verify_function_calls(self, is_test_run, mock_connect, mock_create_skeleton, mock_checksum,
                               write_to_ic_db)
 
     @patch("migrate.create_ingest_metadata.write_to_ic_db")
@@ -189,9 +185,10 @@ class TestMigrate(unittest.TestCase):
     @patch('builtins.open', new_callable=mock_open, read_data="SELECT * FROM TEST")
     @patch('migrate.create_ingest_metadata.create_skeleton_suite_lookup')
     @patch('migrate.create_ingest_metadata.calculate_checksum')
-    @patch('migrate.create_ingest_metadata.get_clients')
+    @patch('migrate.create_ingest_metadata.sqs_client')
+    @patch('migrate.create_ingest_metadata.s3_client')
     def test_migrate_raises_error_if_consignment_ref_and_batch_ref_are_missing(
-            self, get_clients, mock_checksum,
+            self, mock_s3, mock_sqs, mock_checksum,
             mock_create_skeleton, ___, ____, mock_connect, write_to_ic_db
     ):
         row = [
@@ -201,16 +198,12 @@ class TestMigrate(unittest.TestCase):
             "filename.txt", "fileref", "meta", "1", "1", 1, "BornDigital"
         ]
         setup_test(mock_checksum, mock_connect, mock_create_skeleton, [row], write_to_ic_db, None)
-        mock_s3 = MagicMock()
-        mock_sqs = MagicMock()
-        get_clients.return_value = mock_s3, mock_sqs
-
         with self.assertRaises(ValueError) as cm:
             create_ingest_metadata.migrate(self.ic_db_name)
 
         self.assertEqual("We need either a consignment reference or a dri batch reference", str(cm.exception))
 
-        verify_function_calls(self, True, get_clients, mock_connect, mock_create_skeleton, write_to_ic_db,
+        verify_function_calls(self, True, mock_connect, mock_create_skeleton, write_to_ic_db,
                               mock_checksum, ref_error_thrown=True)
 
     def test_skeleton_suite_lookup(self):
@@ -295,26 +288,6 @@ class TestMigrate(unittest.TestCase):
         self.assertEqual(1, count('FileReference', 'ABC/Z'))
         self.assertEqual(1, count('FileReference', 'ABC/Z/1'))
         self.assertEqual(1, count('FileReference', 'DEF/Z'))
-
-    @patch('migrate.create_ingest_metadata.sts_client')
-    def test_get_clients(self,  mock_sts_client):
-        mock_sts_client.assume_role.return_value = {
-            'Credentials': {'AccessKeyId': 'TestAccessKey', 'SecretAccessKey': 'TestSecret', 'SessionToken': 'TestSessionToken'},
-        }
-        def check_client(client):
-            self.assertEqual('eu-west-2', client._client_config.region_name)
-            self.assertEqual('TestAccessKey', client._get_credentials().access_key)
-            self.assertEqual('TestSecret', client._get_credentials().secret_key)
-            self.assertEqual('TestSessionToken', client._get_credentials().token)
-
-        (s3_client, sqs_client) = create_ingest_metadata.get_clients(12345, "test")
-
-        sts_args = mock_sts_client.assume_role.call_args_list[0][1]
-        self.assertEqual('arn:aws:iam::12345:role/test-dr2-ingest-dri-migration-role', sts_args['RoleArn'])
-        self.assertEqual('dri-migration', sts_args['RoleSessionName'])
-
-        check_client(s3_client)
-        check_client(sqs_client)
 
     ic_table_name = "dri_files"
     if os.path.exists(ic_db_name):

--- a/python/dri-migration/migrate/create_ingest_metadata.py
+++ b/python/dri-migration/migrate/create_ingest_metadata.py
@@ -43,18 +43,8 @@ page_size = 100
 config = Config(region_name="eu-west-2")
 
 sts_client = boto3.client("sts")
-
-def get_clients(account_number, environment):
-    credentials = sts_client.assume_role(
-        RoleArn=f"arn:aws:iam::{account_number}:role/{environment}-dr2-ingest-dri-migration-role",
-        RoleSessionName="dri-migration"
-    )['Credentials']
-    access_key = credentials['AccessKeyId']
-    secret_key = credentials['SecretAccessKey']
-    session_token = credentials['SessionToken']
-    s3_client = boto3.client("s3", aws_access_key_id=access_key, aws_secret_access_key=secret_key, aws_session_token=session_token, config=config)
-    sqs_client = boto3.client("sqs", aws_access_key_id=access_key, aws_secret_access_key=secret_key, aws_session_token=session_token, config=config)
-    return s3_client, sqs_client
+s3_client = boto3.client("s3")
+sqs_client = boto3.client("sqs")
 
 
 def calculate_checksum(file_path: str, algorithm: str) -> str:
@@ -97,7 +87,6 @@ def migrate(ic_db_path):
     object_store_bucket = os.environ["OBJECT_STORE_BUCKET"]
     object_store_account_number = os.environ["OBJECT_STORE_ACCOUNT_NUMBER"]
     queue_url = f"https://sqs.eu-west-2.amazonaws.com/{account_number}/{environment}-dr2-preingest-dri-importer"
-    s3_client, sqs_client = get_clients(account_number, environment)
     puid_lookup = create_skeleton_suite_lookup(['fmt', 'x-fmt']) if test_run else {}
     oracledb.defaults.fetch_lobs = False
     oracledb.init_oracle_client(lib_dir=os.environ['CLIENT_LOCATION'])


### PR DESCRIPTION
We're going to be using a user instead. I've removed the get_clients method altogether and updated the tests.
