### PR TITLE
DR2-2932 Replace user with role in KMS key policy.

### DIFF
--- a/terraform/dri_migration.tf
+++ b/terraform/dri_migration.tf
@@ -13,9 +13,8 @@ module "dr2_dri_migration_key" {
       data.aws_iam_role.org_wiz_access_role.arn,
     ]
     user_roles = concat([
-      module.dr2_dri_migration_role.role_arn,
       module.dri_preingest.importer_lambda.role,
-    ], local.e2e_test_roles)
+    ], local.e2e_test_roles, local.environment == "prod" ? ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/prod-dr2-ingest-dri-migration"] : [module.dr2_dri_migration_role.role_arn])
   }
 }
 


### PR DESCRIPTION
The reason I've done it like this with a hard coded string rather than with a data block is if I do
a data block then I have to add the role to the terraform policy which I don't really want to do for a temporary thing.
