### PR TITLE
Update ingest complete message.

### DIFF
--- a/kotlin/e2e-tests/lib/src/main/kotlin/uk/gov/nationalarchives/lib/IngestUtils.kt
+++ b/kotlin/e2e-tests/lib/src/main/kotlin/uk/gov/nationalarchives/lib/IngestUtils.kt
@@ -66,7 +66,7 @@ class IngestUtils(
     private val assetIds: MutableList<UUID>,
     private val groupIds: MutableSet<String>
 ) {
-    private val completeStatus = "Asset has been written to custodial copy disk."
+    private val completeStatus = "Asset has been written to tape"
     private val failedStatus = "There has been an error ingesting the asset."
 
     suspend fun waitForEntriesInLockTable(timeout: Duration = 15.minutes): MutableSet<String> {

--- a/kotlin/e2e-tests/lib/src/test/kotlin/uk/gov/nationalarchives/lib/IngestUtilsTest.kt
+++ b/kotlin/e2e-tests/lib/src/test/kotlin/uk/gov/nationalarchives/lib/IngestUtilsTest.kt
@@ -60,7 +60,7 @@ class IngestUtilsTest {
         val assetId = UUID.randomUUID()
         val body = """{"body": 
             |{"properties": {"executionId": "", "messageType": "preserve.digital.asset.ingest.complete"}, 
-            |"parameters": {"assetId": "$assetId", "status": "Asset has been written to custodial copy disk."}}}""".trimMargin()
+            |"parameters": {"assetId": "$assetId", "status": "Asset has been written to tape"}}}""".trimMargin()
         assertFailsWith<TimeoutException> {
             messageIngestUtils(listOf(body), mutableListOf(assetId))
                 .checkForIngestStatusMessages("", timeout, "update")
@@ -72,7 +72,7 @@ class IngestUtilsTest {
         val assetId = UUID.randomUUID()
         val body = """{"body": 
             |{"properties": {"executionId": "", "messageType": "preserve.digital.asset.ingest.complete"}, 
-            |"parameters": {"assetId": "$assetId", "status": "Asset has been written to custodial copy disk."}}}""".trimMargin()
+            |"parameters": {"assetId": "$assetId", "status": "Asset has been written to tape"}}}""".trimMargin()
         messageIngestUtils(listOf(body), mutableListOf(assetId))
             .checkForIngestStatusMessages("", 1000, "complete")
     }


### PR DESCRIPTION
In the tests, we're checking for preserve.digital.asset.ingest.complete
but we're also checking for the status message which has now changed.
