### PR TITLE
DR2-2933 Remove PA enum

### DIFF
--- a/scala/lambdas/preingest-restore-package-builder/src/test/scala/uk/gov/nationalarchives/preingestrestorepackagebuilder/LambdaTest.scala
+++ b/scala/lambdas/preingest-restore-package-builder/src/test/scala/uk/gov/nationalarchives/preingestrestorepackagebuilder/LambdaTest.scala
@@ -41,7 +41,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
             </OriginalMetadataFiles>
             <TransferDateTime>2023-03-24T10:13:04.280Z</TransferDateTime>
             <TransferringBody/>
-            <UpstreamSystem>Parliament Migration</UpstreamSystem>
+            <UpstreamSystem>DRI</UpstreamSystem>
             <UpstreamSystemRef>SAM/A/123</UpstreamSystemRef>
             <UpstreamPath/>
           </Source>
@@ -92,7 +92,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
     asset.description.isEmpty should equal(true)
     asset.transferringBody should equal(None)
     asset.transferCompleteDatetime.get should equal(OffsetDateTime.parse("2023-03-24T10:13:04.280Z"))
-    asset.upstreamSystem.display should equal("Parliament Migration")
+    asset.upstreamSystem.display should equal("DRI")
     asset.digitalAssetSource should equal("Digital Surrogate")
     asset.digitalAssetSubtype should equal(None)
     asset.filePath should equal("")
@@ -161,7 +161,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
         <Entity>4b44388f-d788-44f7-a61e-21944941598b</Entity>
         <Content>
           <Source>
-            <UpstreamSystem>Parliament Migration</UpstreamSystem>
+            <UpstreamSystem>DRI</UpstreamSystem>
           </Source>
         </Content>
       </Metadata>
@@ -185,7 +185,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
         <Entity>4b44388f-d788-44f7-a61e-21944941598b</Entity>
         <Content>
           <Source>
-            <UpstreamSystem>Parliament Migration</UpstreamSystem>
+            <UpstreamSystem>DRI</UpstreamSystem>
             <DigitalAssetSource>Digital Surrogate</DigitalAssetSource>
           </Source>
         </Content>
@@ -216,7 +216,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
         <Entity>4b44388f-d788-44f7-a61e-21944941598b</Entity>
         <Content>
           <Source>
-            <UpstreamSystem>Parliament Migration</UpstreamSystem>
+            <UpstreamSystem>DRI</UpstreamSystem>
             <DigitalAssetSource>Digital Surrogate</DigitalAssetSource>
           </Source>
         </Content>
@@ -246,7 +246,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
         <Entity>4b44388f-d788-44f7-a61e-21944941598b</Entity>
         <Content>
           <Source>
-            <UpstreamSystem>Parliament Migration</UpstreamSystem>
+            <UpstreamSystem>DRI</UpstreamSystem>
             <DigitalAssetSource>Digital Surrogate</DigitalAssetSource>
           </Source>
         </Content>
@@ -281,7 +281,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
         <Entity>4b44388f-d788-44f7-a61e-21944941598b</Entity>
         <Content>
           <Source>
-            <UpstreamSystem>Parliament Migration</UpstreamSystem>
+            <UpstreamSystem>DRI</UpstreamSystem>
             <DigitalAssetSource>Digital Surrogate</DigitalAssetSource>
           </Source>
         </Content>

--- a/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
@@ -22,7 +22,6 @@ import uk.gov.nationalarchives.preingesttdrpackagebuilder.Lambda.*
 import uk.gov.nationalarchives.utils.ExternalUtils.*
 import uk.gov.nationalarchives.utils.ExternalUtils.given
 import uk.gov.nationalarchives.utils.ExternalUtils.RepresentationType.Preservation
-import uk.gov.nationalarchives.utils.ExternalUtils.SourceSystem.PA
 import uk.gov.nationalarchives.utils.{ExternalUtils, LambdaRunner}
 import uk.gov.nationalarchives.utils.NaturalSorting.{natural, given}
 import uk.gov.nationalarchives.{DADynamoDBClient, DAS3Client}
@@ -60,8 +59,8 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
             assetMetadata <- createAsset(firstPackageMetadata, fileName, originalFilePath, metadataId, potentialMessageId)
             s3FilesMap <- listS3Objects(fileLocation.getHost, potentialFilesPrefix.getOrElse(assetMetadata.id.toString))
             contentFolderKey <- config.sourceSystem match {
-              case SourceSystem.ADHOC | SourceSystem.PA => IO.pure(s"${firstPackageMetadata.series}/$defaultFolderName")
-              case _                                    =>
+              case SourceSystem.ADHOC => IO.pure(s"${firstPackageMetadata.series}/$defaultFolderName")
+              case _                  =>
                 IO.fromOption[String](firstPackageMetadata.consignmentReference.orElse(firstPackageMetadata.driBatchReference))(
                   new Exception(s"We need either a consignment reference or DRI batch reference for ${assetMetadata.id}")
                 )
@@ -83,8 +82,8 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
                 )
               }
               val contentFolderName = config.sourceSystem match {
-                case SourceSystem.ADHOC | SourceSystem.PA => contentFolderKey.split("/").last
-                case _                                    => contentFolderKey
+                case SourceSystem.ADHOC => contentFolderKey.split("/").last
+                case _                  => contentFolderKey
               }
               val potentialContentFolder = contentFolderMap.get(contentFolderKey)
               if potentialContentFolder.isDefined then (contentFolderMap, assetMetadata.copy(parentId = potentialContentFolder.map(_.id)) :: fileMetadataObjs)
@@ -214,8 +213,6 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
           List(IdField(upstreamSystemRefIdKey, s"${packageMetadata.series}/${packageMetadata.fileReference}")) ++
             packageMetadata.driBatchReference.map(driBatchRef => IdField("DRIBatchReference", driBatchRef)).toList ++
             packageMetadata.IAID.map(iaid => IdField(discoveryIaidKey, iaid)).toList
-        case SourceSystem.PA =>
-          packageMetadata.IAID.map(iaid => IdField(discoveryIaidKey, iaid)).toList
         case SourceSystem.ADHOC =>
           List(IdField(upstreamSystemRefIdKey, s"${packageMetadata.series}/${packageMetadata.fileReference}")) ++
             packageMetadata.formerRefDept.map(frd => List(IdField(formerRefDeptIdKey, frd))).getOrElse(Nil) ++
@@ -241,7 +238,7 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
         List(
           IdField(
             "Code",
-            if config.sourceSystem == PA then packageMetadata.fileReference else s"${packageMetadata.series}/${packageMetadata.fileReference}"
+            s"${packageMetadata.series}/${packageMetadata.fileReference}"
           ),
           IdField("RecordID", assetId.toString)
         ) ++ sourceSpecificIdentifiers ++ packageMetadata.consignmentReference.map(consignmentRef => List(IdField("ConsignmentReference", consignmentRef))).getOrElse(Nil)

--- a/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
@@ -13,7 +13,7 @@ import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{Checksum, Inge
 import uk.gov.nationalarchives.preingesttdrpackagebuilder.Lambda.*
 import uk.gov.nationalarchives.preingesttdrpackagebuilder.TestUtils.{*, given}
 import uk.gov.nationalarchives.utils.ExternalUtils.*
-import uk.gov.nationalarchives.utils.ExternalUtils.SourceSystem.{ADHOC, PA, TDR}
+import uk.gov.nationalarchives.utils.ExternalUtils.SourceSystem.{ADHOC, TDR}
 import uk.gov.nationalarchives.utils.NaturalSorting.{natural, given}
 
 import java.net.URI
@@ -223,8 +223,8 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
       case (a, b) => (a.head, b)
     }
     val expectedContentFolderName = testData.upstreamSystem match {
-      case SourceSystem.ADHOC | SourceSystem.PA => "Records"
-      case _                                    => testData.tdrRef.getOrElse(testData.driBatchRef.get)
+      case SourceSystem.ADHOC => "Records"
+      case _                  => testData.tdrRef.getOrElse(testData.driBatchRef.get)
     }
     val expectedTitle =
       if allTestData.length > 1 then
@@ -264,7 +264,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     def checkIdField(name: String, value: String): Unit =
       assetMetadataObject.idFields.find(_.name == name).map(_.value).get should equal(value)
 
-    checkIdField("Code", if testData.upstreamSystem == SourceSystem.PA then testData.fileRef else s"${testData.series}/${testData.fileRef}")
+    checkIdField("Code", s"${testData.series}/${testData.fileRef}")
     if List(SourceSystem.DRI, SourceSystem.ADHOC).contains(testData.upstreamSystem)
     then checkIdField("UpstreamSystemReference", s"${testData.series}/${testData.fileRef}")
     else if testData.upstreamSystem == SourceSystem.TDR then checkIdField("UpstreamSystemReference", testData.fileRef)
@@ -273,8 +273,7 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     testData.tdrRef.foreach(tdrRef => checkIdField("ConsignmentReference", tdrRef))
     checkIdField("RecordID", expectedId.toString)
 
-    if List(SourceSystem.ADHOC, SourceSystem.PA, SourceSystem.DRI).contains(testData.upstreamSystem) && testData.iaid.isDefined then
-      checkIdField("DiscoveryIAID", testData.iaid.get)
+    if SourceSystem.ADHOC == testData.upstreamSystem && testData.iaid.isDefined then checkIdField("DiscoveryIAID", testData.iaid.get)
 
     if testData.upstreamSystem == SourceSystem.DRI && testData.driBatchRef.isDefined && testData.tdrRef.isEmpty then checkIdField("DRIBatchReference", testData.driBatchRef.get)
 
@@ -543,60 +542,6 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     assetMetadataObject.upstreamSystem should be(ADHOC)
     assetMetadataObject.idFields should not contain "FormerRefDept"
     assetMetadataObject.idFields.find(_.name == "FormerRefTNA").map(_.value).get should equal("AB 8/4/6")
-  }
-
-  "lambda handler" should "attach the asset to the correct content folder for pa transfers if there are multiple series" in {
-    def packageMetadata(series: String) = PackageMetadata(
-      series,
-      Option(UUID.randomUUID),
-      None,
-      UUID.randomUUID,
-      None,
-      Option(""),
-      Option("2024-10-04 10:00:00"),
-      None,
-      "test.txt",
-      checksum(""),
-      "",
-      "",
-      None,
-      None,
-      None,
-      None,
-      Some("AB 8/4/6"),
-      None
-    )
-    val packageMetadataOne = packageMetadata("ABC/1")
-    val packageMetadataTwo = packageMetadata("ABC/2")
-
-    val allMetadata = List(packageMetadataOne, packageMetadataTwo)
-
-    val initialDynamoObjects = allMetadata
-      .map { packageMetadata =>
-        val lockTableMessage = new LockTableMessage(UUID.randomUUID(), URI.create(s"s3://bucket/${packageMetadata.UUID}.metadata")).asJson.noSpaces
-        IngestLockTableItem(UUID.randomUUID(), "TST-123", lockTableMessage, dateTimeNow.toString)
-      }
-
-    val initialS3Objects = allMetadata.flatMap { packageMetadata =>
-      List(s"${packageMetadata.UUID}.metadata" -> List(packageMetadata).asJson.noSpaces, s"${packageMetadata.UUID}/${packageMetadata.fileId}" -> MockTdrFile(1))
-    }.toMap
-
-    val paConfig: Config = Config("", "", "cacheBucket", 1, PA)
-    val (s3Contents, output) = runHandler(initialS3Objects = initialS3Objects, initialDynamoObjects = initialDynamoObjects, config = paConfig)
-
-    val s3Objects = s3Contents("/metadata.json")
-    val metadataList = s3Objects.asInstanceOf[List[MetadataObject]]
-    val assetNameToParent = metadataList.collect { case a: AssetMetadataObject => a.name -> a.parentId.get }.toMap
-    val contentIdToName = metadataList.collect { case c: ContentFolderMetadataObject => c.id -> c.series.get }.toMap
-
-    def checkAssetParent(packageMetadata: PackageMetadata, expectedName: String) = {
-      val assetParent = assetNameToParent(packageMetadata.UUID.get.toString)
-      contentIdToName(assetParent) should equal(expectedName)
-    }
-
-    checkAssetParent(packageMetadataOne, "ABC/1")
-    checkAssetParent(packageMetadataTwo, "ABC/2")
-
   }
 
   "lambda handler" should "return an error if the dynamo query fails" in {

--- a/scala/lambdas/utils/src/main/scala/uk/gov/nationalarchives/utils/ExternalUtils.scala
+++ b/scala/lambdas/utils/src/main/scala/uk/gov/nationalarchives/utils/ExternalUtils.scala
@@ -317,7 +317,6 @@ object ExternalUtils {
     case DRI extends SourceSystem("DRI")
     case `TRE: FCL Parser workflow` extends SourceSystem("TRE: FCL Parser workflow")
     case ADHOC extends SourceSystem("Ad hoc ingest")
-    case PA extends SourceSystem("Parliament Migration")
     case COURTDOC extends SourceSystem("TRE: FCL Parser workflow")
 
     override def toString: String = display


### PR DESCRIPTION
This is the last reference to the Parliament migration in code I can find.

I can't be 100% sure because PA is a very common string but I think I've got it all
