### PR TITLE
Send payload as json.

### DIFF
--- a/scala/lambdas/postingest-message-resender/src/main/scala/uk/gov/nationalarchives/postingestresender/Lambda.scala
+++ b/scala/lambdas/postingest-message-resender/src/main/scala/uk/gov/nationalarchives/postingestresender/Lambda.scala
@@ -4,9 +4,11 @@ import cats.effect.IO
 import cats.effect.std.Semaphore
 import cats.syntax.all.*
 import com.amazonaws.services.lambda.runtime.events.ScheduledEvent
-import io.circe.Encoder
+import io.circe.Encoder.encodeString
+import io.circe.{Encoder, Json}
 import io.circe.generic.semiauto.deriveEncoder
 import io.circe.jawn.decode
+import io.circe.parser.parse
 import org.scanamo.query.AndCondition
 import org.scanamo.syntax.*
 import pureconfig.ConfigReader
@@ -60,14 +62,16 @@ class Lambda extends LambdaRunner[ScheduledEvent, Unit, Config, Dependencies] {
 
     def sendToQueue(item: PostIngestStateTableItem, queue: Queue, semaphore: Semaphore[IO]): IO[Unit] = {
       semaphore.permit.use { _ =>
-        dependencies.sqsClient
-          .sendMessage(queue.queueUrl)(QueueMessage(item.assetId, item.batchId, queue.resultAttrName, item.input))
-          .handleErrorWith { error =>
-            logger.error(s"""Failed to send message for assetId '${item.assetId}' to '${queue.queueAlias}' queue:
-                 |${error.getMessage}""".stripMargin) >>
-              IO.raiseError(error)
-          }
-          .void
+        IO.fromEither(parse(item.input)).flatMap { payloadJson =>
+          dependencies.sqsClient
+            .sendMessage(queue.queueUrl)(QueueMessage(item.assetId, item.batchId, queue.resultAttrName, payloadJson))
+            .handleErrorWith { error =>
+              logger.error(s"""Failed to send message for assetId '${item.assetId}' to '${queue.queueAlias}' queue:
+                   |${error.getMessage}""".stripMargin) >>
+                IO.raiseError(error)
+            }
+            .void
+        }
       }
     }
 
@@ -105,5 +109,5 @@ class Lambda extends LambdaRunner[ScheduledEvent, Unit, Config, Dependencies] {
 object Lambda {
   case class Config(stateTableName: String, stateGsiName: String, queues: String) derives ConfigReader
   case class Dependencies(dynamoClient: DADynamoDBClient[IO], sqsClient: DASQSClient[IO], instantGenerator: () => Instant)
-  case class QueueMessage(assetId: UUID, batchId: String, resultAttributeName: String, payload: String)
+  case class QueueMessage(assetId: UUID, batchId: String, resultAttributeName: String, payload: Json)
 }

--- a/scala/lambdas/postingest-message-resender/src/test/scala/uk/gov/nationalarchives/postingestresender/LambdaTest.scala
+++ b/scala/lambdas/postingest-message-resender/src/test/scala/uk/gov/nationalarchives/postingestresender/LambdaTest.scala
@@ -58,7 +58,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
       PostIngestStateTableItem(
         assetId1,
         "batchId",
-        "input_message_payload1",
+        """{"input_message":"payload1"}""",
         Some("correlationId"),
         Some("CC"),
         Some(Instant.now().minus(java.time.Duration.ofDays(10)).toString),
@@ -69,7 +69,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
       PostIngestStateTableItem(
         assetId2,
         "batchId1",
-        "input_message_payload2",
+        """{"input_message":"payload2"}""",
         Some("correlationId1"),
         Some("CC"),
         Some(Instant.now().minus(java.time.Duration.ofDays(16)).toString),
@@ -92,8 +92,8 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
       decode[QueueMessage](message.getBody).getOrElse(throw new RuntimeException("could not decode messages"))
     }
     messages.size should be(2)
-    messages.find(_.assetId == assetId1).get.payload should be("input_message_payload1")
-    messages.find(_.assetId == assetId2).get.payload should be("input_message_payload2")
+    messages.find(_.assetId == assetId1).get.payload.findAllByKey("input_message").head.asString.get should be("payload1")
+    messages.find(_.assetId == assetId2).get.payload.findAllByKey("input_message").head.asString.get should be("payload2")
   }
 
   "handler" should "not update 'lastQueued' time for an item belonging to a different queue" in {
@@ -107,7 +107,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
       PostIngestStateTableItem(
         uuidForUpdate,
         "batchId",
-        "this_message_to_be_resent",
+        """{"this_message":"to_be_resent"}""",
         Some("correlationId"),
         Some("CC"),
         Some(sixDaysOld),
@@ -142,7 +142,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
       decode[QueueMessage](message.getBody).getOrElse(throw new RuntimeException("could not decode messages"))
     }
     messages.size should be(1)
-    messages.find(_.assetId == uuidForUpdate).get.payload should be("this_message_to_be_resent")
+    messages.find(_.assetId == uuidForUpdate).get.payload.findAllByKey("this_message").head.asString.get should be("to_be_resent")
   }
 
   "handler" should "report error when it cannot fetch queue attributes" in {
@@ -177,7 +177,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues:
       PostIngestStateTableItem(
         UUID.randomUUID(),
         "batchId",
-        "input",
+        "{}",
         Some("correlationId"),
         Some("CC"),
         Some(Instant.now().minus(java.time.Duration.ofDays(6)).toString),


### PR DESCRIPTION
The postingest state change handler has changed to send the payload as json instead
of a string and the confirmers have been changed to accept it. The resender is still sending the
payload as a string. This should fix it.
