### PR TITLE
Increase DRI aggregator timeout.

### DIFF
--- a/terraform/preingest.tf
+++ b/terraform/preingest.tf
@@ -52,6 +52,9 @@ module "dri_preingest" {
     })
   } : {}
   additional_importer_lambda_env_vars = local.environment == "prod" ? { RECORDS_METADATA_BUCKET = local.records_metadata_bucket_name } : {}
+  aggregator_lambda                   = {
+    timeout = 180
+  }
 }
 
 module "ad_hoc_preingest" {

--- a/terraform/preingest.tf
+++ b/terraform/preingest.tf
@@ -52,7 +52,7 @@ module "dri_preingest" {
     })
   } : {}
   additional_importer_lambda_env_vars = local.environment == "prod" ? { RECORDS_METADATA_BUCKET = local.records_metadata_bucket_name } : {}
-  aggregator_lambda                   = {
+  aggregator_lambda = {
     timeout = 180
   }
 }

--- a/terraform/preingest/preingest.tf
+++ b/terraform/preingest/preingest.tf
@@ -12,7 +12,7 @@ locals {
   java_lambda_memory_size                      = 512
   java_timeout_seconds                         = 180
   aggregator_primary_grouping_window_seconds   = var.aggregator_primary_grouping_window_seconds # How long the SQS Poller waits before invoking the Lambda after receiving the first message. Defaults to <=300 for Lambda.
-  aggregator_lambda_timeout_seconds            = 60                                             # <=900 for Lambda.
+  aggregator_lambda_timeout_seconds            = var.aggregator_lambda.timeout                  # <=900 for Lambda.
   aggregator_secondary_grouping_window_seconds = var.aggregator_secondary_grouping_window_seconds
   aggregator_invocation_batch_size             = 10000                                                                                      # Max number of messages to invoke the Lambda with, but all messages need to be processed before the Lambda times out. <=10000 for Lambda.
   aggregator_group_size                        = 10000                                                                                      # Max size of an aggregation group.

--- a/terraform/preingest/variables.tf
+++ b/terraform/preingest/variables.tf
@@ -47,6 +47,15 @@ variable "private_subnet_ids" {
   default = []
 }
 
+variable "aggregator_lambda" {
+  type = object({
+    timeout = number
+  })
+  default = {
+    timeout = 60
+  }
+}
+
 variable "importer_lambda" {
   type = object({
     timeout            = number


### PR DESCRIPTION
With around 3000 records, the lambda takes around 100 seconds which was timing out
which caused the aggregator to create a lot of smaller ingests.

This should be enough for a while.
