### PR TITLE
DR2-2948 Handle multiple series withe same batch reference

### DIFF
--- a/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
@@ -59,11 +59,11 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
             assetMetadata <- createAsset(firstPackageMetadata, fileName, originalFilePath, metadataId, potentialMessageId)
             s3FilesMap <- listS3Objects(fileLocation.getHost, potentialFilesPrefix.getOrElse(assetMetadata.id.toString))
             contentFolderKey <- config.sourceSystem match {
-              case SourceSystem.ADHOC => IO.pure(s"${firstPackageMetadata.series}/$defaultFolderName")
+              case SourceSystem.ADHOC => IO.pure(s"${firstPackageMetadata.series}$defaultFolderName")
               case _                  =>
                 IO.fromOption[String](firstPackageMetadata.consignmentReference.orElse(firstPackageMetadata.driBatchReference))(
                   new Exception(s"We need either a consignment reference or DRI batch reference for ${assetMetadata.id}")
-                ).map(reference => s"${firstPackageMetadata.series}/$reference")
+                ).map(reference => s"${firstPackageMetadata.series}$reference")
             }
             metadataObjects <- contentFolderCell.modify[List[MetadataObject]] { contentFolderMap =>
               val fileMetadataObjs: List[FileMetadataObject] = packageMetadataList.sortBy(p => natural(p.filename)).zipWithIndex.map { (packageMetadata, idx) =>
@@ -82,7 +82,7 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
                 )
               }
 
-              val contentFolderName = contentFolderKey.replace(s"${firstPackageMetadata.series}/", "")
+              val contentFolderName = contentFolderKey.substring(firstPackageMetadata.series.length)
               val potentialContentFolder = contentFolderMap.get(contentFolderKey)
               if potentialContentFolder.isDefined then (contentFolderMap, assetMetadata.copy(parentId = potentialContentFolder.map(_.id)) :: fileMetadataObjs)
               else

--- a/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/main/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/Lambda.scala
@@ -63,7 +63,7 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
               case _                  =>
                 IO.fromOption[String](firstPackageMetadata.consignmentReference.orElse(firstPackageMetadata.driBatchReference))(
                   new Exception(s"We need either a consignment reference or DRI batch reference for ${assetMetadata.id}")
-                )
+                ).map(reference => s"${firstPackageMetadata.series}/$reference")
             }
             metadataObjects <- contentFolderCell.modify[List[MetadataObject]] { contentFolderMap =>
               val fileMetadataObjs: List[FileMetadataObject] = packageMetadataList.sortBy(p => natural(p.filename)).zipWithIndex.map { (packageMetadata, idx) =>
@@ -81,10 +81,8 @@ class Lambda extends LambdaRunner[Input, Output, Config, Dependencies]:
                   packageMetadata.checksums
                 )
               }
-              val contentFolderName = config.sourceSystem match {
-                case SourceSystem.ADHOC => contentFolderKey.split("/").last
-                case _                  => contentFolderKey
-              }
+
+              val contentFolderName = contentFolderKey.replace(s"${firstPackageMetadata.series}/", "")
               val potentialContentFolder = contentFolderMap.get(contentFolderKey)
               if potentialContentFolder.isDefined then (contentFolderMap, assetMetadata.copy(parentId = potentialContentFolder.map(_.id)) :: fileMetadataObjs)
               else

--- a/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
@@ -430,7 +430,6 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
     assetMetadataObjects.count(_.parentId == Option(contentFolderMetadataObjects.last.id)) should equal(1)
   }
 
-
   "lambda handler" should "return an error if the metadata list is empty" in {
     val ex = intercept[Exception] {
       runHandler()

--- a/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
+++ b/scala/lambdas/preingest-tdr-package-builder/src/test/scala/uk/gov/nationalarchives/preingesttdrpackagebuilder/LambdaTest.scala
@@ -372,6 +372,65 @@ class LambdaTest extends AnyFlatSpec with ScalaCheckDrivenPropertyChecks:
 
   }
 
+  "lambda handler" should "create two content folders for two consignments two different series but the same consignment reference" in {
+    val uuidIterator: () => UUID = () => UUID.randomUUID
+
+    def packageMetadata(series: String, fileId: UUID) = PackageMetadata(
+      series,
+      None,
+      Option(UUID.randomUUID),
+      fileId,
+      None,
+      Option("body"),
+      Option("2024-10-18 00:00:01"),
+      Option("consignmentReference"),
+      s"file.txt",
+      checksum("checksum"),
+      "reference",
+      "/path/to/file.txt",
+      None,
+      None,
+      None,
+      None,
+      None,
+      None
+    ) :: Nil
+
+    val groupId = UUID.randomUUID.toString
+    val batchId = s"${groupId}_0"
+
+    def createInitialS3Objects(assetId: UUID, fileId: UUID, series: String): Map[String, S3Objects] =
+      Map(
+        s"$assetId.metadata" -> packageMetadata(series, fileId).asJson.noSpaces,
+        s"$assetId/$fileId" -> MockTdrFile(1)
+      )
+
+    val (assetIdOne, assetIdTwo, fileIdOne, fileIdTwo) = (UUID.randomUUID, UUID.randomUUID, UUID.randomUUID, UUID.randomUUID)
+
+    val initialS3Objects = createInitialS3Objects(assetIdOne, fileIdOne, "TST 123") ++ createInitialS3Objects(assetIdTwo, fileIdTwo, "TST 234")
+
+    val initialDynamoObjects = List(assetIdOne, assetIdTwo).map { assetId =>
+      val lockTableMessage = NotificationMessage(UUID.randomUUID(), URI.create(s"s3://bucket/$assetId.metadata")).asJson.noSpaces
+      IngestLockTableItem(UUID.randomUUID(), groupId, lockTableMessage, dateTimeNow.toString)
+    }
+
+    val input = Input(groupId, batchId, 1, 2)
+    val (s3Contents, output) = runHandler(uuidIterator, initialS3Objects, initialDynamoObjects, input)
+
+    val metadataObjects: List[MetadataObject] = s3Contents(s"$batchId/metadata.json").asInstanceOf[List[MetadataObject]]
+    val assetMetadataObjects = metadataObjects.collect { case assetMetadataObject: AssetMetadataObject => assetMetadataObject }
+    val contentFolderMetadataObjects = metadataObjects.collect { case contentFolderMetadataObject: ContentFolderMetadataObject => contentFolderMetadataObject }
+
+    contentFolderMetadataObjects.size should equal(2)
+
+    contentFolderMetadataObjects.count(_.series.contains("TST 123")) should equal(1)
+    contentFolderMetadataObjects.count(_.series.contains("TST 234")) should equal(1)
+
+    assetMetadataObjects.count(_.parentId == Option(contentFolderMetadataObjects.head.id)) should equal(1)
+    assetMetadataObjects.count(_.parentId == Option(contentFolderMetadataObjects.last.id)) should equal(1)
+  }
+
+
   "lambda handler" should "return an error if the metadata list is empty" in {
     val ex = intercept[Exception] {
       runHandler()


### PR DESCRIPTION
We have had a DRI migration ingest where assets from multiple different series all had the same DRI batch reference. The package builder handles this for adhoc (where the reference is always “Records”) but doesn’t handle it for other ingests.
