### PR TITLE
Checkout the deploy version ref.

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,8 @@ jobs:
         with:
           submodules: recursive
           token: ${{ secrets.WORKFLOW_TOKEN }}
+          ref: ${{ github.event.inputs.to-deploy }}
+          persist-credentials: false
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
         with:
           terraform_wrapper: false
@@ -87,6 +89,7 @@ jobs:
           token: ${{ secrets.WORKFLOW_TOKEN }}
           fetch-tags: true
           persist-credentials: true
+          ref: ${{ github.event.inputs.to-deploy }}
       - uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - id: role-name
         run: echo role-name="$(echo $ENVIRONMENT | sed -r 's/(^|-)(\w)/\U\2/g')TerraformRole" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The deploy jobs take around 2 hours to go from merge to main to deploy to prod
If anything else is merged to main in this time, the prod deploy will deploy these
changes as well.

The lambdas which are deployed are still the correct version as they are pulled from
s3 with a prefix matching the version but any terraform changes go in untested.

This should sort it.
