### PR TITLE
DR2-2960 Make flow control honour reserved channels

### DIFF
--- a/scala/lambdas/ingest-flow-control/README.md
+++ b/scala/lambdas/ingest-flow-control/README.md
@@ -72,7 +72,8 @@ each invocation of the lambda sends task success to, at most, one task. This lam
 1.It then reads the configuration, iterates over all the systems mentioned in the config to find a matching task in dynamoDB table. Since the iteration is done based on system names rather than executions, it is possible that an exeuction started by one system may progress a waiting execution from another system.
    4. Once it reads an entry from the configuration, it finds a list of all tasks from the dynamoDB table for that system. If there is a channel available for the system, it calls "sendTaskSuccess" for that system and invocation of this lambda eventually terminates.
    5. If there are not enough reserved channels for the system, it carries on iterating over the remaining systems to try and call "sendTaskSuccess" on any running execution
-   6. If there are no reserved channels available for any system, it tries to schedule a task based on probability.
+   6. It then calculates whether there are spare channels in the system. It adds the number of running executions to the number of reserved channels, excluding those reserved channels which are already in use. If this is less than the maximum concurrency, then there are spare channels.  
+   7. If there are no reserved channels available for any system, and there are spare channels, it tries to schedule a task based on probability.
 2. For progressing a task based on probability, it iterates over all the systems in the configuration by systemName
    1. It finds the number of free channels available and calculates the probability range for the system
    2. It generates a random number between 1 and 100 (both inclusive) and if the random number falls within the probability range of the system, it calls "sendTaskSuccess" for that system and invocation of this lambda eventually terminates.

--- a/scala/lambdas/ingest-flow-control/src/main/scala/uk/gov/nationalarchives/ingestflowcontrol/Lambda.scala
+++ b/scala/lambdas/ingest-flow-control/src/main/scala/uk/gov/nationalarchives/ingestflowcontrol/Lambda.scala
@@ -27,25 +27,25 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
     val executionStarter = potentialInput.map(_.executionName).getOrElse("NO_EXECUTION_NAME")
 
     /** A recursive method to send task success to one and only one task per invocation. It takes a list of source systems, iterates over the list (recursively) to start a task on
-     * first system which has a reserved channel available
-     * @param sourceSystems
-     *   List of source systems to iterate over
-     * @param executionsBySystem
-     *   Map of SystemName -> count of running executions
-     * @param flowControlConfig
-     *   Flow control configuration
-     * @param taskExecutorName
-     *   Name of the task executor which sent the success
-     * @return
-     *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system or an empty
-     *   string to indicate that there is nothing more to do
-     */
+      * first system which has a reserved channel available
+      * @param sourceSystems
+      *   List of source systems to iterate over
+      * @param executionsBySystem
+      *   Map of SystemName -> count of running executions
+      * @param flowControlConfig
+      *   Flow control configuration
+      * @param taskExecutorName
+      *   Name of the task executor which sent the success
+      * @return
+      *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system or an empty
+      *   string to indicate that there is nothing more to do
+      */
     def startTaskOnReservedChannel(
-                                    sourceSystems: List[SourceSystem],
-                                    executionsBySystem: Map[String, Int],
-                                    flowControlConfig: FlowControlConfig,
-                                    taskExecutorName: String
-                                  ): IO[String] = {
+        sourceSystems: List[SourceSystem],
+        executionsBySystem: Map[String, Int],
+        flowControlConfig: FlowControlConfig,
+        taskExecutorName: String
+    ): IO[String] = {
       if sourceSystems.isEmpty then
         logInfo("Reserved channel: No more source systems to iterate over", taskExecutorName) >>
           IO.pure(taskExecutorName)
@@ -86,20 +86,20 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
     }
 
     /** A recursive method to send success to one of the systems, based on probability as configured in the Flow control configuration. It builds a probability ranges map based on
-     * the config (e.g. TDR -> (1, 25), FCL -> (25, 40) ... ). It then generates a random number between the minimum and maximum value over all probabilities and tries to schedule
-     * a task for that system. If there is no task waiting for the system, it recreates the probability map excluding that system from the config and generates a random number for
-     * the remaining systems only, thus making sure that the probabilities are honoured over all iterations.
-     *
-     * The probability of each system is kept intact in relation to each other, even if one of the systems does not have a waiting task. e.g. if there are 3 systems, one, two, and
-     * three with probabilities of 25, 55, 20, the ranges being 1-26, 26-81, 81-101. For this example, let's assume that system "two" does not have a waiting task. Iteration 1 -
-     * random number generated is 30 (which corresponds to system "two"), since system "two" does not have a waiting task, Iteration 2 - a new ranges map is constructed by
-     * excluding system "two" (1-26, 26-47) and a new number is generated between 1 and 47 this ensures that the probability in relation to each other is kept intact for the
-     * remaining systems
-     * @param sourceSystems
-     *   List of source systems to iterate for starting a task
-     * @return
-     *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system
-     */
+      * the config (e.g. TDR -> (1, 25), FCL -> (25, 40) ... ). It then generates a random number between the minimum and maximum value over all probabilities and tries to schedule
+      * a task for that system. If there is no task waiting for the system, it recreates the probability map excluding that system from the config and generates a random number for
+      * the remaining systems only, thus making sure that the probabilities are honoured over all iterations.
+      *
+      * The probability of each system is kept intact in relation to each other, even if one of the systems does not have a waiting task. e.g. if there are 3 systems, one, two, and
+      * three with probabilities of 25, 55, 20, the ranges being 1-26, 26-81, 81-101. For this example, let's assume that system "two" does not have a waiting task. Iteration 1 -
+      * random number generated is 30 (which corresponds to system "two"), since system "two" does not have a waiting task, Iteration 2 - a new ranges map is constructed by
+      * excluding system "two" (1-26, 26-47) and a new number is generated between 1 and 47 this ensures that the probability in relation to each other is kept intact for the
+      * remaining systems
+      * @param sourceSystems
+      *   List of source systems to iterate for starting a task
+      * @return
+      *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system
+      */
     def startTaskBasedOnProbability(sourceSystems: List[SourceSystem]): IO[String] = {
       sourceSystems match
         case Nil =>
@@ -252,13 +252,13 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
   }
 
   private def logInfo(
-                       message: String,
-                       executionName: String,
-                       currentSystem: String = "",
-                       remainingSystems: String = "",
-                       queuedTimeAndExecution: String = "",
-                       resumedExecution: String = ""
-                     ): IO[Unit] = {
+      message: String,
+      executionName: String,
+      currentSystem: String = "",
+      remainingSystems: String = "",
+      queuedTimeAndExecution: String = "",
+      resumedExecution: String = ""
+  ): IO[Unit] = {
     logger.info(
       Map(
         "executionName" -> executionName,
@@ -271,25 +271,25 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
   }
 
   /** Builds a map of system name to a range. Range is a case class representing a starting point (inclusive) and ending point (exclusive) of the range. e.g. A config where
-   * "System1" has 30% probability and "System2" has 15% probability will look like: "System1" -> Range(1, 31) "System2" -> Range(31, 46)
-   *
-   * If the probability for any system is zero, such system is excluded from the generated map
-   *
-   * @param systems
-   *   list of @SourceSystem
-   * @param rangeStart
-   *   starting point for the next range iteration
-   * @param sourceSystemProbabilityRanges
-   *   accumulator to build the map of all ranges
-   * @return
-   *   map of system name to probability ranges
-   */
+    * "System1" has 30% probability and "System2" has 15% probability will look like: "System1" -> Range(1, 31) "System2" -> Range(31, 46)
+    *
+    * If the probability for any system is zero, such system is excluded from the generated map
+    *
+    * @param systems
+    *   list of @SourceSystem
+    * @param rangeStart
+    *   starting point for the next range iteration
+    * @param sourceSystemProbabilityRanges
+    *   accumulator to build the map of all ranges
+    * @return
+    *   map of system name to probability ranges
+    */
   @tailrec
   final def buildProbabilityRangesMap(
-                                       systems: List[Lambda.SourceSystem],
-                                       rangeStart: Int,
-                                       sourceSystemProbabilityRanges: Map[String, Range]
-                                     ): Map[String, Range] = {
+      systems: List[Lambda.SourceSystem],
+      rangeStart: Int,
+      sourceSystemProbabilityRanges: Map[String, Range]
+  ): Map[String, Range] = {
     systems match
       case Nil => sourceSystemProbabilityRanges
       case _   =>

--- a/scala/lambdas/ingest-flow-control/src/main/scala/uk/gov/nationalarchives/ingestflowcontrol/Lambda.scala
+++ b/scala/lambdas/ingest-flow-control/src/main/scala/uk/gov/nationalarchives/ingestflowcontrol/Lambda.scala
@@ -15,6 +15,7 @@ import uk.gov.nationalarchives.dynamoformatters.DynamoFormatters.{*, given}
 
 import java.time.Instant
 import scala.annotation.tailrec
+import scala.math.*
 import uk.gov.nationalarchives.DADynamoDBClient.given
 import org.scanamo.syntax.*
 import software.amazon.awssdk.services.sfn.model.TaskTimedOutException
@@ -26,25 +27,25 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
     val executionStarter = potentialInput.map(_.executionName).getOrElse("NO_EXECUTION_NAME")
 
     /** A recursive method to send task success to one and only one task per invocation. It takes a list of source systems, iterates over the list (recursively) to start a task on
-      * first system which has a reserved channel available
-      * @param sourceSystems
-      *   List of source systems to iterate over
-      * @param executionsBySystem
-      *   Map of SystemName -> count of running executions
-      * @param flowControlConfig
-      *   Flow control configuration
-      * @param taskExecutorName
-      *   Name of the task executor which sent the success
-      * @return
-      *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system or an empty
-      *   string to indicate that there is nothing more to do
-      */
+     * first system which has a reserved channel available
+     * @param sourceSystems
+     *   List of source systems to iterate over
+     * @param executionsBySystem
+     *   Map of SystemName -> count of running executions
+     * @param flowControlConfig
+     *   Flow control configuration
+     * @param taskExecutorName
+     *   Name of the task executor which sent the success
+     * @return
+     *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system or an empty
+     *   string to indicate that there is nothing more to do
+     */
     def startTaskOnReservedChannel(
-        sourceSystems: List[SourceSystem],
-        executionsBySystem: Map[String, Int],
-        flowControlConfig: FlowControlConfig,
-        taskExecutorName: String
-    ): IO[String] = {
+                                    sourceSystems: List[SourceSystem],
+                                    executionsBySystem: Map[String, Int],
+                                    flowControlConfig: FlowControlConfig,
+                                    taskExecutorName: String
+                                  ): IO[String] = {
       if sourceSystems.isEmpty then
         logInfo("Reserved channel: No more source systems to iterate over", taskExecutorName) >>
           IO.pure(taskExecutorName)
@@ -85,20 +86,20 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
     }
 
     /** A recursive method to send success to one of the systems, based on probability as configured in the Flow control configuration. It builds a probability ranges map based on
-      * the config (e.g. TDR -> (1, 25), FCL -> (25, 40) ... ). It then generates a random number between the minimum and maximum value over all probabilities and tries to schedule
-      * a task for that system. If there is no task waiting for the system, it recreates the probability map excluding that system from the config and generates a random number for
-      * the remaining systems only, thus making sure that the probabilities are honoured over all iterations.
-      *
-      * The probability of each system is kept intact in relation to each other, even if one of the systems does not have a waiting task. e.g. if there are 3 systems, one, two, and
-      * three with probabilities of 25, 55, 20, the ranges being 1-26, 26-81, 81-101. For this example, let's assume that system "two" does not have a waiting task. Iteration 1 -
-      * random number generated is 30 (which corresponds to system "two"), since system "two" does not have a waiting task, Iteration 2 - a new ranges map is constructed by
-      * excluding system "two" (1-26, 26-47) and a new number is generated between 1 and 47 this ensures that the probability in relation to each other is kept intact for the
-      * remaining systems
-      * @param sourceSystems
-      *   List of source systems to iterate for starting a task
-      * @return
-      *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system
-      */
+     * the config (e.g. TDR -> (1, 25), FCL -> (25, 40) ... ). It then generates a random number between the minimum and maximum value over all probabilities and tries to schedule
+     * a task for that system. If there is no task waiting for the system, it recreates the probability map excluding that system from the config and generates a random number for
+     * the remaining systems only, thus making sure that the probabilities are honoured over all iterations.
+     *
+     * The probability of each system is kept intact in relation to each other, even if one of the systems does not have a waiting task. e.g. if there are 3 systems, one, two, and
+     * three with probabilities of 25, 55, 20, the ranges being 1-26, 26-81, 81-101. For this example, let's assume that system "two" does not have a waiting task. Iteration 1 -
+     * random number generated is 30 (which corresponds to system "two"), since system "two" does not have a waiting task, Iteration 2 - a new ranges map is constructed by
+     * excluding system "two" (1-26, 26-47) and a new number is generated between 1 and 47 this ensures that the probability in relation to each other is kept intact for the
+     * remaining systems
+     * @param sourceSystems
+     *   List of source systems to iterate for starting a task
+     * @return
+     *   IO[String]: name of the task executor which sent success, a hard coded string "CONTINUE_TO_NEXT_SYSTEM" to indicate that no task was sent for the tried system
+     */
     def startTaskBasedOnProbability(sourceSystems: List[SourceSystem]): IO[String] = {
       sourceSystems match
         case Nil =>
@@ -224,6 +225,7 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
       flowControlConfig <- dependencies.ssmClient.getParameter[FlowControlConfig](config.configParamName)
       _ <- writeTaskToQueueTable(flowControlConfig)
       runningExecutions <- dependencies.stepFunctionClient.listStepFunctions(config.stepFunctionArn, Running)
+      _ <- logInfo(s"Found ${runningExecutions.length} running executions", executionStarter)
       taskSuccessExecutor <-
         if runningExecutions.size < flowControlConfig.maxConcurrency && flowControlConfig.enabled then
           if flowControlConfig.hasReservedChannels then
@@ -232,7 +234,7 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
               if taskExecutorName.nonEmpty then
                 logInfo("Task started successfully on reserved channel. Terminating lambda", executionStarter, resumedExecution = taskExecutorName) >>
                   IO.pure(taskExecutorName)
-              else if (flowControlConfig.hasSpareChannels)
+              else if flowControlConfig.hasSpareChannels(executionsMap) then
                 logInfo("Attempting to start task based on probability", executionStarter) >>
                   startTaskBasedOnProbability(flowControlConfig.sourceSystems)
               else
@@ -250,13 +252,13 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
   }
 
   private def logInfo(
-      message: String,
-      executionName: String,
-      currentSystem: String = "",
-      remainingSystems: String = "",
-      queuedTimeAndExecution: String = "",
-      resumedExecution: String = ""
-  ): IO[Unit] = {
+                       message: String,
+                       executionName: String,
+                       currentSystem: String = "",
+                       remainingSystems: String = "",
+                       queuedTimeAndExecution: String = "",
+                       resumedExecution: String = ""
+                     ): IO[Unit] = {
     logger.info(
       Map(
         "executionName" -> executionName,
@@ -269,25 +271,25 @@ class Lambda extends LambdaRunner[Option[Input], TaskOutput, Config, Dependencie
   }
 
   /** Builds a map of system name to a range. Range is a case class representing a starting point (inclusive) and ending point (exclusive) of the range. e.g. A config where
-    * "System1" has 30% probability and "System2" has 15% probability will look like: "System1" -> Range(1, 31) "System2" -> Range(31, 46)
-    *
-    * If the probability for any system is zero, such system is excluded from the generated map
-    *
-    * @param systems
-    *   list of @SourceSystem
-    * @param rangeStart
-    *   starting point for the next range iteration
-    * @param sourceSystemProbabilityRanges
-    *   accumulator to build the map of all ranges
-    * @return
-    *   map of system name to probability ranges
-    */
+   * "System1" has 30% probability and "System2" has 15% probability will look like: "System1" -> Range(1, 31) "System2" -> Range(31, 46)
+   *
+   * If the probability for any system is zero, such system is excluded from the generated map
+   *
+   * @param systems
+   *   list of @SourceSystem
+   * @param rangeStart
+   *   starting point for the next range iteration
+   * @param sourceSystemProbabilityRanges
+   *   accumulator to build the map of all ranges
+   * @return
+   *   map of system name to probability ranges
+   */
   @tailrec
   final def buildProbabilityRangesMap(
-      systems: List[Lambda.SourceSystem],
-      rangeStart: Int,
-      sourceSystemProbabilityRanges: Map[String, Range]
-  ): Map[String, Range] = {
+                                       systems: List[Lambda.SourceSystem],
+                                       rangeStart: Int,
+                                       sourceSystemProbabilityRanges: Map[String, Range]
+                                     ): Map[String, Range] = {
     systems match
       case Nil => sourceSystemProbabilityRanges
       case _   =>
@@ -336,7 +338,12 @@ object Lambda {
     require(sourceSystems.map(_.systemName).contains(default), "Missing 'DEFAULT' system in the configuration")
 
     val hasReservedChannels: Boolean = reservedChannelsCount > 0
-    val hasSpareChannels: Boolean = reservedChannelsCount < maxConcurrency
+    def hasSpareChannels(executionsMap: Map[String, Int]): Boolean =
+      val totalReservedChannels = sourceSystems.foldLeft(0) { (totalReserved, sourceSystem) =>
+        totalReserved + max(sourceSystem.reservedChannels - executionsMap.getOrElse(sourceSystem.systemName, 0), 0)
+      }
+      (executionsMap.values.sum + totalReservedChannels) < maxConcurrency
+
   }
 
   case class Range(startInclusive: Int, endExclusive: Int)

--- a/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/Helpers.scala
+++ b/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/Helpers.scala
@@ -18,7 +18,7 @@ object Helpers {
 
   def notImplemented[T]: IO[Nothing] = IO.raiseError(new Exception("Not implemented"))
 
-  def predictableRandomNumberSelector(selected: Int = 10): (Int, Int) => Int = (min, max) => if selected > max then max else selected
+  def predictableRandomNumberSelector(selected: Int = 10): (Int, Int) => Int = (min, max) => if selected > max then max - 1 else selected
 
   def runLambda(
       input: Option[Input],

--- a/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
+++ b/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
@@ -151,7 +151,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
     lambdaRunResult.finalStepFnExecutions.forall(!_.taskTokenSuccess) should be(true)
   }
 
-  "lambda" should s"send task success to a running task when there is a max concurrency less than the number of running tasks + reserved channels for running source systems" in {
+  "lambda" should s"send task success to a running task when there is a max concurrency more than the number of running tasks + reserved channels for running source systems" in {
     val initialDynamo = (1 to 5).map { i =>
       IngestQueueTableItem("DRI", Instant.now.minus(Duration.ofHours(1)).toString + "_DRI_2ec6248e_0", s"task-token-$i", "DRI_2ec6248e_0")
     }.toList

--- a/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
+++ b/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
@@ -131,6 +131,45 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
     lambdaRunResult.finalStepFnExecutions.find(_.taskToken == "a-task-already-running").exists(_.taskTokenSuccess) should be(false)
   }
 
+  "lambda" should s"add a new task to dynamo but not send success when there is a max concurrency of 6, 5 running tasks and 1 reserved channel for another source system" in {
+    val initialDynamo = (1 to 5).map { i =>
+      IngestQueueTableItem("DRI", Instant.now.minus(Duration.ofHours(1)).toString + "_DRI_2ec6248e_0", s"task-token-$i", "DRI_2ec6248e_0")
+    }.toList
+
+    val validSourceSystems = List(SourceSystem("TDR", 1, 54), SourceSystem("DRI", 0, 1), SourceSystem("DEFAULT", 0, 45))
+    val initialConfig = FlowControlConfig(6, validSourceSystems, true)
+    val existingExecutions = (1 to 5).map { i =>
+      StepFunctionExecution(s"DRI_$i", s"DRI_$i")
+    }.toList
+    val input = Option(Input("DRI_execution_name_2", "task-token-for-dri"))
+
+    val lambdaRunResult = runLambda(input, initialDynamo, initialConfig, existingExecutions, predictableRandomNumberSelector())
+
+    lambdaRunResult.result.isRight should be(true)
+    lambdaRunResult.finalItemsInTable should have length 6
+    lambdaRunResult.finalItemsInTable.map(_.taskToken).contains("task-token-for-dri") should be(true)
+    lambdaRunResult.finalStepFnExecutions.forall(!_.taskTokenSuccess) should be(true)
+  }
+
+  "lambda" should s"send task success to a running task when there is a max concurrency of 6, 5 running tasks and 1 reserved channel for a running source system" in {
+    val initialDynamo = (1 to 5).map { i =>
+      IngestQueueTableItem("DRI", Instant.now.minus(Duration.ofHours(1)).toString + "_DRI_2ec6248e_0", s"task-token-$i", "DRI_2ec6248e_0")
+    }.toList
+
+    val validSourceSystems = List(SourceSystem("TDR", 1, 54), SourceSystem("DRI", 0, 1), SourceSystem("DEFAULT", 0, 45))
+    val initialConfig = FlowControlConfig(6, validSourceSystems, true)
+    val existingExecutions = (1 to 4).map { i =>
+      StepFunctionExecution(s"DRI_$i", s"task-token-$i")
+    }.toList :+ StepFunctionExecution("TDR_1", "TDR_1")
+
+    val lambdaRunResult = runLambda(None, initialDynamo, initialConfig, existingExecutions, predictableRandomNumberSelector())
+
+    lambdaRunResult.result.isRight should be(true)
+    lambdaRunResult.finalItemsInTable should have length 4
+    lambdaRunResult.finalStepFnExecutions.count(!_.taskTokenSuccess) should be(4)
+    lambdaRunResult.finalStepFnExecutions.find(_.taskTokenSuccess).get.name should be("DRI_1")
+  }
+
   forAll(enabledTable) { enabled =>
     val prefix = if enabled then "" else "not"
     "lambda" should s"$prefix process tasks from existing entries in the dynamo table when no task token is passed in the input with enabled $enabled" in {
@@ -431,13 +470,13 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
       ),
       true
     )
-    configWithSpareChannels.hasSpareChannels should be(true)
+    configWithSpareChannels.hasSpareChannels(Map("SystemOne" -> 1, "DEFAULT" -> 1)) should be(true)
   }
 
   "FlowControlConfig" should "indicate lack of spare channels when reserved channels equal the maximum concurrency" in {
     val configWithAllChannelsReserved =
       Lambda.FlowControlConfig(4, List(Lambda.SourceSystem("SystemOne", 1, 25), Lambda.SourceSystem("SystemTwo", 1, 35), Lambda.SourceSystem("DEFAULT", 2, 40)), true)
-    configWithAllChannelsReserved.hasSpareChannels should be(false)
+    configWithAllChannelsReserved.hasSpareChannels(Map("SystemThree" -> 4)) should be(false)
   }
 
   "FlowControlConfig" should "indicate true when at least one of the systems in the config has a reserved channel" in {

--- a/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
+++ b/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
@@ -474,9 +474,9 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
   }
 
   "FlowControlConfig" should "indicate lack of spare channels when reserved channels + running executions equal the maximum concurrency" in {
-    val configWithAllChannelsReserved =
-      Lambda.FlowControlConfig(4, List(Lambda.SourceSystem("SystemOne", 1, 25), Lambda.SourceSystem("SystemTwo", 1, 35), Lambda.SourceSystem("DEFAULT", 2, 40)), true)
-    configWithAllChannelsReserved.hasSpareChannels(Map("SystemThree" -> 4)) should be(false)
+    val configWithHalfChannelsReserved =
+      Lambda.FlowControlConfig(8, List(Lambda.SourceSystem("SystemOne", 1, 25), Lambda.SourceSystem("SystemTwo", 1, 35), Lambda.SourceSystem("DEFAULT", 2, 40)), true)
+    configWithHalfChannelsReserved.hasSpareChannels(Map("SystemThree" -> 4)) should be(false)
   }
 
   "FlowControlConfig" should "indicate true when at least one of the systems in the config has a reserved channel" in {

--- a/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
+++ b/scala/lambdas/ingest-flow-control/src/test/scala/uk/gov/nationalarchives/ingestflowcontrol/LambdaTest.scala
@@ -131,7 +131,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
     lambdaRunResult.finalStepFnExecutions.find(_.taskToken == "a-task-already-running").exists(_.taskTokenSuccess) should be(false)
   }
 
-  "lambda" should s"add a new task to dynamo but not send success when there is a max concurrency of 6, 5 running tasks and 1 reserved channel for another source system" in {
+  "lambda" should s"add a new task to dynamo but not send success when there is a max concurrency less than the number of running tasks + reserved channels for another source system" in {
     val initialDynamo = (1 to 5).map { i =>
       IngestQueueTableItem("DRI", Instant.now.minus(Duration.ofHours(1)).toString + "_DRI_2ec6248e_0", s"task-token-$i", "DRI_2ec6248e_0")
     }.toList
@@ -151,7 +151,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
     lambdaRunResult.finalStepFnExecutions.forall(!_.taskTokenSuccess) should be(true)
   }
 
-  "lambda" should s"send task success to a running task when there is a max concurrency of 6, 5 running tasks and 1 reserved channel for a running source system" in {
+  "lambda" should s"send task success to a running task when there is a max concurrency less than the number of running tasks + reserved channels for running source systems" in {
     val initialDynamo = (1 to 5).map { i =>
       IngestQueueTableItem("DRI", Instant.now.minus(Duration.ofHours(1)).toString + "_DRI_2ec6248e_0", s"task-token-$i", "DRI_2ec6248e_0")
     }.toList
@@ -473,7 +473,7 @@ class LambdaTest extends AnyFlatSpec with EitherValues with TableDrivenPropertyC
     configWithSpareChannels.hasSpareChannels(Map("SystemOne" -> 1, "DEFAULT" -> 1)) should be(true)
   }
 
-  "FlowControlConfig" should "indicate lack of spare channels when reserved channels equal the maximum concurrency" in {
+  "FlowControlConfig" should "indicate lack of spare channels when reserved channels + running executions equal the maximum concurrency" in {
     val configWithAllChannelsReserved =
       Lambda.FlowControlConfig(4, List(Lambda.SourceSystem("SystemOne", 1, 25), Lambda.SourceSystem("SystemTwo", 1, 35), Lambda.SourceSystem("DEFAULT", 2, 40)), true)
     configWithAllChannelsReserved.hasSpareChannels(Map("SystemThree" -> 4)) should be(false)


### PR DESCRIPTION
The `hasSpareChannels` value is used to determine whether or not to start a probability
based task after it has tried to start one on the reserved channels.

As it was, were doing `reservedChannelsCount < maxConcurrency` which for the prod config
is 1 < 6 which is always true so we were always starting a new task up to the maxConcurrency.

This now passes the running execution count in. So if maxConcurrency is 6, there is one reserved
channel and there are 5 existing executions, it won't start another one.
