### PR TITLE
DR2-2974 Revert courtdoc aggregator changes

### DIFF
--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -124,19 +124,14 @@ locals {
       enabled        = true,
       sourceSystems = [
         {
-          systemName       = local.source_systems[index(local.source_systems, "TDR")]
-          reservedChannels = 1
-          probability      = 54
-        },
-        {
           systemName       = local.source_systems[index(local.source_systems, "DRI")]
           reservedChannels = 0
           probability      = 1
         },
         {
           systemName       = local.source_systems[index(local.source_systems, "DEFAULT")]
-          reservedChannels = 0
-          probability      = 45
+          reservedChannels = 1
+          probability      = 99
         }
       ]
     }

--- a/terraform/preingest.tf
+++ b/terraform/preingest.tf
@@ -79,14 +79,13 @@ module "ad_hoc_preingest" {
 }
 
 module "court_document_preingest" {
-  source                                       = "./preingest"
-  environment                                  = local.environment
-  aggregator_secondary_grouping_window_seconds = 60 * 60 * 4
-  ingest_lock_dynamo_table_name                = local.ingest_lock_dynamo_table_name
-  ingest_lock_table_arn                        = module.ingest_lock_table.table_arn
-  ingest_lock_table_group_id_gsi_name          = local.ingest_lock_table_group_id_gsi_name
-  ingest_raw_cache_bucket_name                 = local.ingest_raw_cache_bucket_name
-  ingest_step_function_name                    = local.ingest_step_function_name
+  source                              = "./preingest"
+  environment                         = local.environment
+  ingest_lock_dynamo_table_name       = local.ingest_lock_dynamo_table_name
+  ingest_lock_table_arn               = module.ingest_lock_table.table_arn
+  ingest_lock_table_group_id_gsi_name = local.ingest_lock_table_group_id_gsi_name
+  ingest_raw_cache_bucket_name        = local.ingest_raw_cache_bucket_name
+  ingest_step_function_name           = local.ingest_step_function_name
   sns_topic_subscription = local.environment == "prod" ? {
     topic_arn     = module.tre_config.terraform_config[local.tre_environment_name]["da_eventbus"],
     filter_policy = templatefile("${path.module}/templates/sns/tre_live_stream_filter_policy.json.tpl", {})


### PR DESCRIPTION
As part of the flow control config in DR2-2909 we changed the batching window for the courtdoc preingest to 4 hours to try and aggregate lots of court docs into one. This isn’t actually working and it’s causing the e2e tests to fail because the courtdoc preingest waits for 4 hours.

This needs to be reverted and the flow control in prod to be updated to remove TDR and add a reserved channel for DEFAULT. This means that TDR and COURTDOC can share the reserved channel. As neither of these ingests usually take very long, this should be fine.
