### PR TITLE
DR2-2944 Add more logging and move dependencies

### DIFF
--- a/scala/lambdas/postprocess-cleanup-handler/src/main/resources/log4j2.properties
+++ b/scala/lambdas/postprocess-cleanup-handler/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+status = warn
+
+name = DR2LambdaLogConfiguration
+
+appender.console.type = Console
+appender.console.name = consoleLogger
+appender.console.json.type = JsonTemplateLayout
+
+rootLogger.level = info
+
+rootLogger.appenderRef.stdout.ref = consoleLogger

--- a/scala/lambdas/postprocess-cleanup-handler/src/main/scala/uk/gov/nationalarchives/postprocesscleanup/Lambda.scala
+++ b/scala/lambdas/postprocess-cleanup-handler/src/main/scala/uk/gov/nationalarchives/postprocesscleanup/Lambda.scala
@@ -21,6 +21,8 @@ import software.amazon.awssdk.services.dynamodb.model.AttributeValue
 class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
   private val deletionTagMap = Map("TO_BE_DELETED" -> "true")
 
+  private lazy val dependencies = Dependencies(DADynamoDBClient[IO](), DAS3Client[IO]())
+
   override def handler: (SQSEvent, Config, Dependencies) => IO[Unit] = (sqsEvent, config, dependencies) =>
     val ttlAfter1Day = System.currentTimeMillis() / 1000 + 24 * 3600
 
@@ -67,8 +69,13 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
 
         _ <- logger.info(s"Updating TTL for children of assetId $assetId")
         _ <- fileItems.traverse { fileItem =>
-          dependencies.s3Client.updateObjectTags(config.rawCacheBucketName, fileItem.location.getPath.drop(1), deletionTagMap) >>
-            updateTtl(fileItem.id.toString)
+          val key = fileItem.location.getPath.drop(1)
+          for
+            _ <- logger.info(s"Updating object tags for $key")
+            _ <- dependencies.s3Client.updateObjectTags(config.rawCacheBucketName, key, deletionTagMap)
+            _ <- logger.info(s"Updating ttl for ${fileItem.id}")
+            _ <- updateTtl(fileItem.id.toString)
+          yield ()
         }
 
         potentialParentPath = assetItem.potentialParentPath.getOrElse("")
@@ -80,9 +87,7 @@ class Lambda extends LambdaRunner[SQSEvent, Unit, Config, Dependencies] {
   def getParentPathForChildren(assetItem: DynamoItem): String =
     s"${assetItem.potentialParentPath.map(path => s"$path/").getOrElse("")}${assetItem.id}"
 
-  override def dependencies(config: Config): IO[Dependencies] = IO(
-    Dependencies(DADynamoDBClient[IO](), DAS3Client[IO]())
-  )
+  override def dependencies(config: Config): IO[Dependencies] = IO.pure(dependencies)
 }
 
 object Lambda {


### PR DESCRIPTION
Because IO doesn't memoise whatever is inside it, the constructor for the
s3 and dynamo client are being called every time the lamdba is run which is why
it's running out of file handles.

Constructing it outside the handler means that it is only created once every time the lambda
starts from cold.

I've also added in a small amount of extra logging and added the log4j file that allows the logging
to work
