### PR TITLE
DR2-2967 Aggregator off by one error

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -77,4 +77,5 @@ object Dependencies {
   lazy val nettyTransport = "io.netty" % "netty-transport" % nettyVersion
   lazy val httpcore5 = "org.apache.httpcomponents.core5" % "httpcore5" % httpcoreVersion
   lazy val httpcore5H2 = "org.apache.httpcomponents.core5" % "httpcore5-h2" % httpcoreVersion
+  lazy val httpClient = "org.apache.httpcomponents.client5" % "httpclient5" % "5.6.4"
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -11,6 +11,7 @@ object Dependencies {
   private lazy val scalaTestVersion = "3.2.20"
   private lazy val nettyVersion = "4.2.16.Final"
   private lazy val jacksonVersion = "3.2.1"
+  private lazy val httpcoreVersion = "5.4.3"
 
   lazy val awsCrt = "software.amazon.awssdk.crt" % "aws-crt" % "0.47.3"
   lazy val awsLambda = "com.amazonaws" % "aws-java-sdk-lambda" % awsLibraryVersion
@@ -74,4 +75,6 @@ object Dependencies {
   lazy val nettyResolver = "io.netty" % "netty-resolver" % nettyVersion
   lazy val nettyTransportClasses = "io.netty" % "netty-transport-classes-epoll" % nettyVersion
   lazy val nettyTransport = "io.netty" % "netty-transport" % nettyVersion
+  lazy val httpcore5 = "org.apache.httpcomponents.core5" % "httpcore5" % httpcoreVersion
+  lazy val httpcore5H2 = "org.apache.httpcomponents.core5" % "httpcore5-h2" % httpcoreVersion
 }

--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -89,6 +89,7 @@ lazy val commonSettings = Seq(
     commonsLogging,
     httpcore5,
     httpcore5H2,
+    httpClient,
     jawnParser
   ),
   assembly / assemblyOutputPath := file(s"target/outputs/${name.value}"),

--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -86,7 +86,9 @@ lazy val commonSettings = Seq(
     nettyResolver,
     nettyTransportClasses,
     nettyTransport,
-    commonsLogging,
+    commonsLogging,    
+    httpcore5,
+    httpcore5H2,
     jawnParser
   ),
   assembly / assemblyOutputPath := file(s"target/outputs/${name.value}"),

--- a/scala/lambdas/build.sbt
+++ b/scala/lambdas/build.sbt
@@ -86,7 +86,7 @@ lazy val commonSettings = Seq(
     nettyResolver,
     nettyTransportClasses,
     nettyTransport,
-    commonsLogging,    
+    commonsLogging,
     httpcore5,
     httpcore5H2,
     jawnParser

--- a/scala/lambdas/preingest-aggregator/README.md
+++ b/scala/lambdas/preingest-aggregator/README.md
@@ -34,7 +34,7 @@ Once the lambda is invoked, each message is processed in parallel via a fibre. T
          - Since the expiry comprises the lambdaTimeoutTime + maxSecondaryBatchingWindow, what determines whether to
            create a new group is how much time is left on the maxSecondaryBatchingWindow; if there is 0 time left, then
            the group is ready to be processed and should not have anything added to it
-      2. If the item count is more than the batch size, create a new group
+      2. If the item count is more than or equal to the maximum batch size, create a new group
       3. Otherwise, increment the itemCount of the group (for that sourceId) and save it back to the cache
 4. If a group is to be created then it will:
    1. Generate a new group ID

--- a/scala/lambdas/preingest-aggregator/src/main/scala/uk/gov/nationalarchives/preingestaggregator/Aggregator.scala
+++ b/scala/lambdas/preingest-aggregator/src/main/scala/uk/gov/nationalarchives/preingestaggregator/Aggregator.scala
@@ -119,7 +119,7 @@ object Aggregator:
                 case Some(currentGroupForSource) =>
                   if currentGroupForSource.expires.toEpochMilli <= lambdaTimeoutTime.length then
                     log(ExpiryBeforeLambdaTimeout) >> startNewGroup(config, groupExpiryTime, msgInput.id, msgBody)
-                  else if currentGroupForSource.itemCount > config.maxBatchSize then log(MaxGroupSizeExceeded) >> startNewGroup(config, groupExpiryTime, msgInput.id, msgBody)
+                  else if currentGroupForSource.itemCount >= config.maxBatchSize then log(MaxGroupSizeExceeded) >> startNewGroup(config, groupExpiryTime, msgInput.id, msgBody)
                   else
                     writeToLockTable(msgInput.id, msgBody, config, currentGroupForSource.groupId) >>
                       Async[F].pure(currentGroupForSource.copy(itemCount = currentGroupForSource.itemCount + 1))

--- a/scala/lambdas/preingest-aggregator/src/test/scala/uk/gov/nationalarchives/preingestaggregator/AggregatorTest.scala
+++ b/scala/lambdas/preingest-aggregator/src/test/scala/uk/gov/nationalarchives/preingestaggregator/AggregatorTest.scala
@@ -210,6 +210,36 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
     checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
   }
 
+  "aggregate" should "add a new group to the existing group if the expiry is before the lambda timeout and items is equal to max batch size" in {
+    val assetId = UUID.randomUUID
+    val existingGroupId = GroupId("TST")
+    val earlier = instant.minusMillis(10000)
+    val groupCache = Map("eventSourceArn" -> Group(existingGroupId, earlier, 10))
+    val output = getAggregatorOutput(List(assetId), groupCache).unsafeRunSync()
+
+    output.failures.isEmpty should equal(true)
+    output.group.size should equal(1)
+    checkSnsMessages(assetId, newBatchId, output.notificationsMessages)
+    checkGroup(output.group.head._2, groupId, instant.plusMillis(2000), 1)
+    checkSfnArgs(output.sfnArgs.head, newBatchId, groupId)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
+  }
+
+  "aggregate" should "add a new group to the existing group if the expiry is after the lambda timeout and items is equal to max batch size" in {
+    val assetId = UUID.randomUUID
+    val existingGroupId = GroupId("TST")
+    val earlier = instant.plusMillis(10000)
+    val groupCache = Map("eventSourceArn" -> Group(existingGroupId, earlier, 10))
+    val output = getAggregatorOutput(List(assetId), groupCache).unsafeRunSync()
+
+    output.failures.isEmpty should equal(true)
+    output.group.size should equal(1)
+    checkSnsMessages(assetId, newBatchId, output.notificationsMessages)
+    checkGroup(output.group.head._2, groupId, instant.plusMillis(2000), 1)
+    checkSfnArgs(output.sfnArgs.head, newBatchId, groupId)
+    checkWriteItemArgs(output.dynamoItems, List(assetId), groupId)
+  }
+
   "aggregate" should "update the existing group's 'itemCount' if the expiry is after the lambda timeout and the group is smaller than the max" in {
     val assetId = UUID.randomUUID
     val existingGroupId = GroupId("TST")

--- a/scala/lambdas/preingest-aggregator/src/test/scala/uk/gov/nationalarchives/preingestaggregator/AggregatorTest.scala
+++ b/scala/lambdas/preingest-aggregator/src/test/scala/uk/gov/nationalarchives/preingestaggregator/AggregatorTest.scala
@@ -228,8 +228,8 @@ class AggregatorTest extends AnyFlatSpec with EitherValues:
   "aggregate" should "add a new group to the existing group if the expiry is after the lambda timeout and items is equal to max batch size" in {
     val assetId = UUID.randomUUID
     val existingGroupId = GroupId("TST")
-    val earlier = instant.plusMillis(10000)
-    val groupCache = Map("eventSourceArn" -> Group(existingGroupId, earlier, 10))
+    val later = instant.plusMillis(10000)
+    val groupCache = Map("eventSourceArn" -> Group(existingGroupId, later, 10))
     val output = getAggregatorOutput(List(assetId), groupCache).unsafeRunSync()
 
     output.failures.isEmpty should equal(true)


### PR DESCRIPTION
If `itemCount` was 10000 and the `maxBatchSize` was 10000, it was hitting the
final else branch and writing to the lock table. Then on the next run when `itemCount`
was 10001, it would start a new group.

I've added a couple of tests to check for this.
