### PR TITLE
NOJIRA Re-enable non-prod environments

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -9,7 +9,7 @@ object Dependencies {
   private val log4CatsVersion = "2.8.0"
   private val awsLibraryVersion = "1.12.797"
   private lazy val scalaTestVersion = "3.2.20"
-  private lazy val nettyVersion = "4.2.16.Final"
+  private lazy val nettyVersion = "4.2.17.Final"
   private lazy val jacksonVersion = "3.2.1"
   private lazy val httpcoreVersion = "5.4.3"
 

--- a/terraform/common.tf
+++ b/terraform/common.tf
@@ -109,8 +109,8 @@ locals {
 
   flow_control_configs = {
     intg = {
-      maxConcurrency = 1,
-      enabled        = false,
+      maxConcurrency = 2,
+      enabled        = true,
       sourceSystems = [
         {
           systemName       = local.default
@@ -120,7 +120,7 @@ locals {
       ]
     }
     prod = {
-      maxConcurrency = 8,
+      maxConcurrency = 4,
       enabled        = true,
       sourceSystems = [
         {
@@ -136,8 +136,8 @@ locals {
       ]
     }
     staging = {
-      maxConcurrency = 1,
-      enabled        = false,
+      maxConcurrency = 2,
+      enabled        = true,
       sourceSystems = [
         {
           systemName       = local.default


### PR DESCRIPTION
Re-enables Flow Control in non-prod environments now that the large ingest has completed. When this deploys it'll revert  the manual configuration changes we made to get the large ingest through.